### PR TITLE
[Feature] Support the creation of collections from geopandas

### DIFF
--- a/docs_source/pages/notebooks/generate_xml_from_qupath_export.ipynb
+++ b/docs_source/pages/notebooks/generate_xml_from_qupath_export.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -181,7 +181,7 @@
        "4                            POINT (1353.77 1165.83)  "
       ]
      },
-     "execution_count": 30,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -200,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -285,7 +285,7 @@
        "4  POINT (1353.77 1165.83)  "
       ]
      },
-     "execution_count": 32,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -296,7 +296,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -355,7 +355,7 @@
        "1  POLYGON ((1789 990, 1730 1153, 1744 1467, 1944...  "
       ]
      },
-     "execution_count": 33,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -376,7 +376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -387,7 +387,7 @@
        "       [ 361.78, 2301.51]])"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -409,7 +409,77 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>objectType</th>\n",
+       "      <th>name</th>\n",
+       "      <th>geometry</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>9287277d-e46f-47e9-aa3f-c540b3318b5e</td>\n",
+       "      <td>annotation</td>\n",
+       "      <td>region2</td>\n",
+       "      <td>POLYGON ((507 1524, 506.6 1539.01, 505.39 1553...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>ab63cfd3-17d0-4dd3-b8e6-95172dda64de</td>\n",
+       "      <td>annotation</td>\n",
+       "      <td>Region1</td>\n",
+       "      <td>POLYGON ((1789 990, 1730 1153, 1744 1467, 1944...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                     id  objectType     name  \\\n",
+       "0  9287277d-e46f-47e9-aa3f-c540b3318b5e  annotation  region2   \n",
+       "1  ab63cfd3-17d0-4dd3-b8e6-95172dda64de  annotation  Region1   \n",
+       "\n",
+       "                                            geometry  \n",
+       "0  POLYGON ((507 1524, 506.6 1539.01, 505.39 1553...  \n",
+       "1  POLYGON ((1789 990, 1730 1153, 1744 1467, 1944...  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "annotations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -443,7 +513,7 @@
     "    )\n",
     "\n",
     "# Load geopandas into collection class \n",
-    "shape_collection.load_geopandas(annotations)\n",
+    "shape_collection.load_geopandas(annotations, name_column=\"name\")\n",
     "\n",
     "shape_collection.stats()"
    ]
@@ -457,7 +527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -492,9 +562,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ 34324. -36853.]\n",
+      "[ 135377. -116583.]\n",
+      "[  36178. -230151.]\n"
+     ]
+    }
+   ],
    "source": [
     "shape_collection.save(\"./test_data/cellculture_example/shapes_2.xml\")"
    ]

--- a/docs_source/pages/notebooks/generate_xml_from_qupath_export.ipynb
+++ b/docs_source/pages/notebooks/generate_xml_from_qupath_export.ipynb
@@ -27,73 +27,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/sophia/mambaforge/envs/pylmd_docs/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# import required libraries\n",
-    "import json\n",
-    "import geojson \n",
+    "import shapely\n",
     "import geopandas\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "\n",
-    "from lmd.lib import Collection, Shape"
+    "from lmd.lib import Collection"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#define helper functions\n",
+    "def separate_points_polygons(df: geopandas.GeoDataFrame, geometry_column: str = \"geometry\") -> tuple[geopandas.GeoDataFrame, geopandas.GeoDataFrame]:\n",
+    "    \"\"\"Split QuPath geopandas dataframe by shape types\"\"\"\n",
+    "    points = df[geometry_column].apply(lambda geom: isinstance(geom, shapely.Point))\n",
+    "    polygons = df[geometry_column].apply(lambda geom: isinstance(geom, shapely.Polygon))\n",
     "\n",
-    "def get_calib_points(list_of_calibpoint_names, df):\n",
-    "    #create shape list\n",
+    "    return df.loc[points], df.loc[polygons]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_calib_points(list_of_calibpoint_names: str, df: geopandas.GeoDataFrame) -> np.ndarray:\n",
+    "    \"\"\"Parse selected points into np.array\"\"\"\n",
+    "\n",
+    "    #Create list of relevant shapes\n",
     "    pointlist = []\n",
     "    for point_name in list_of_calibpoint_names:\n",
     "        pointlist.append(df.loc[df['name'] == point_name, 'geometry'].values[0])\n",
     "    \n",
-    "    #create coordinate list\n",
-    "    listarray = []\n",
-    "    for point in pointlist:\n",
-    "        listarray.append([point.x, point.y])\n",
-    "    nparray = np.array(listarray)\n",
-    "    \n",
-    "    return(nparray)\n",
-    "\n",
-    "#returns dataframe with only polygon objects\n",
-    "def remove_non_polygons(df):\n",
-    "    import shapely\n",
-    "    \n",
-    "    df_filtered = df.loc[[type(x) == shapely.geometry.polygon.Polygon for x in df.geometry]]\n",
-    "    return(df_filtered)\n",
-    "\n",
-    "#creates new column for coordenates in a list of list format\n",
-    "#assumes only polygons in dataframe\n",
-    "def replace_coords(df):\n",
-    "    df['coordinates_shape_exterior'] = np.nan\n",
-    "    df['coordinates_shape_exterior'] = df['coordinates_shape_exterior'].astype('object')\n",
-    "    \n",
-    "    for i in df.index:\n",
-    "        #get geometry object for row i\n",
-    "        geom = df.at[i, 'geometry']\n",
-    "        #list the coordinate points as tuples\n",
-    "        tmp = list(geom.exterior.coords)\n",
-    "        #transform list of tuples to list of lists and save to dataframe\n",
-    "        df.at[i,'coordinates_shape_exterior'] = [list(i) for i in tmp]\n",
-    "    \n",
-    "    return(df)\n"
+    "    return np.array([[point.x, point.y] for point in pointlist])"
    ]
   },
   {
@@ -105,15 +79,16 @@
     "\n",
     "The geojson dataset is loaded into a dataframe with the following structure:\n",
     "\n",
-    "id                     objectType                          classification                              name                       geometry\n",
-    "unique shape id        type of shape (e.g. annotation)     all annotation information from qupath      shape name if given        contains information relevant for shape\n",
+    "id | objectType  | classification | name | geometry |\n",
+    "--- | --- | --- | --- | --- \n",
+    "unique shape id  |  type of shape (e.g. annotation)  |    all annotation information from qupath    |  shape name if given      |  contains information relevant for shape\n",
     "\n",
     "The geojson should besides containing individual segemnted shapes contain 3 points annotated as calib1, calib2, calib3 that will be used as calibration points for generating the XML"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -206,7 +181,7 @@
        "4                            POINT (1353.77 1165.83)  "
       ]
      },
-     "execution_count": 3,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -217,67 +192,34 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Calibration points"
+    "Annotations and calibration points (`shapely.Point` objects) and annoatations (`shapely.Polygon` objects) should be processed separately. Therefore, we will use the previously defined helper function `separate_points_polygons` to split the dataframe by shape type."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 31,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[ 343.24  368.53]\n",
-      " [1353.77 1165.83]\n",
-      " [ 361.78 2301.51]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "#assumes user will always label their calibration points like this \n",
-    "caliblist = get_calib_points(['calib1','calib2','calib3'],df)\n",
-    "print(caliblist)"
+    "# Separate calibration points (shapely.Points) from annotations (shapely.Polygons)\n",
+    "points, annotations = separate_points_polygons(df)"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Clean up Dataframe\n",
-    "\n",
-    "Remove non-polygon shapes, extract polygon coordinates, and parse annotation for easier use"
+    "Let's inspect the separated geodataframes"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/sophia/mambaforge/envs/pylmd_docs/lib/python3.10/site-packages/geopandas/geodataframe.py:1819: SettingWithCopyWarning: \n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "  super().__setitem__(key, value)\n",
-      "/Users/sophia/mambaforge/envs/pylmd_docs/lib/python3.10/site-packages/geopandas/geodataframe.py:1819: SettingWithCopyWarning: \n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "  super().__setitem__(key, value)\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -303,7 +245,85 @@
        "      <th>objectType</th>\n",
        "      <th>name</th>\n",
        "      <th>geometry</th>\n",
-       "      <th>coordinates_shape_exterior</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>b60d2cf7-963e-42ae-8a2a-69ff289d29db</td>\n",
+       "      <td>annotation</td>\n",
+       "      <td>calib1</td>\n",
+       "      <td>POINT (343.24 368.53)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>56bdd076-ac9a-4950-97f3-b8c2268ee090</td>\n",
+       "      <td>annotation</td>\n",
+       "      <td>calib3</td>\n",
+       "      <td>POINT (361.78 2301.51)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>03d9bb6e-16b1-4cd9-9181-86da90fb98bf</td>\n",
+       "      <td>annotation</td>\n",
+       "      <td>calib2</td>\n",
+       "      <td>POINT (1353.77 1165.83)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                     id  objectType    name  \\\n",
+       "2  b60d2cf7-963e-42ae-8a2a-69ff289d29db  annotation  calib1   \n",
+       "3  56bdd076-ac9a-4950-97f3-b8c2268ee090  annotation  calib3   \n",
+       "4  03d9bb6e-16b1-4cd9-9181-86da90fb98bf  annotation  calib2   \n",
+       "\n",
+       "                  geometry  \n",
+       "2    POINT (343.24 368.53)  \n",
+       "3   POINT (361.78 2301.51)  \n",
+       "4  POINT (1353.77 1165.83)  "
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "points"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>objectType</th>\n",
+       "      <th>name</th>\n",
+       "      <th>geometry</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -313,7 +333,6 @@
        "      <td>annotation</td>\n",
        "      <td>region2</td>\n",
        "      <td>POLYGON ((507 1524, 506.6 1539.01, 505.39 1553...</td>\n",
-       "      <td>[[507.0, 1524.0], [506.6, 1539.01], [505.39, 1...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -321,7 +340,6 @@
        "      <td>annotation</td>\n",
        "      <td>Region1</td>\n",
        "      <td>POLYGON ((1789 990, 1730 1153, 1744 1467, 1944...</td>\n",
-       "      <td>[[1789.0, 990.0], [1730.0, 1153.0], [1744.0, 1...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -332,24 +350,18 @@
        "0  9287277d-e46f-47e9-aa3f-c540b3318b5e  annotation  region2   \n",
        "1  ab63cfd3-17d0-4dd3-b8e6-95172dda64de  annotation  Region1   \n",
        "\n",
-       "                                            geometry  \\\n",
-       "0  POLYGON ((507 1524, 506.6 1539.01, 505.39 1553...   \n",
-       "1  POLYGON ((1789 990, 1730 1153, 1744 1467, 1944...   \n",
-       "\n",
-       "                          coordinates_shape_exterior  \n",
-       "0  [[507.0, 1524.0], [506.6, 1539.01], [505.39, 1...  \n",
-       "1  [[1789.0, 990.0], [1730.0, 1153.0], [1744.0, 1...  "
+       "                                            geometry  \n",
+       "0  POLYGON ((507 1524, 506.6 1539.01, 505.39 1553...  \n",
+       "1  POLYGON ((1789 990, 1730 1153, 1744 1467, 1944...  "
       ]
      },
-     "execution_count": 5,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df_poly = remove_non_polygons(df)\n",
-    "df_poly = replace_coords(df_poly)\n",
-    "df_poly"
+    "annotations"
    ]
   },
   {
@@ -357,32 +369,47 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Generate shape collection"
+    "## Calibration points\n",
+    "\n",
+    "pyLMD expects calibration points as numpy array of the shape (N, 2). We therefore need to extract the coordinates of the calibration points from the `points` geodataframe. To do so, we will use the second helper function `get_calib_points` that converts the `geometry` column of the selected points to a numpy array. Each row in the numpy array represents the coordinates of the calibration points in (x, y) format. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 343.24,  368.53],\n",
+       "       [1353.77, 1165.83],\n",
+       "       [ 361.78, 2301.51]])"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "shape_collection = Collection(calibration_points = caliblist)\n",
-    "shape_collection.orientation_transform = np.array([[1,0 ], [0,-1]])"
+    "caliblist = get_calib_points(['calib1','calib2','calib3'], points)\n",
+    "caliblist"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 7,
+   "attachments": {},
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "for i in df_poly.index:\n",
-    "    shape_collection.new_shape(df_poly.loc[i,'coordinates_shape_exterior'], well = \"well1\") # can define a well if so wished otherwise leave out"
+    "## Generate shape collection\n",
+    "\n",
+    "We are now able to convert the annotation dataframe to a collection of shapes. To do so, we initialize an empty pylmd `Collection` with the previously defined calibration points. We will further define the flip the axes of the points with an `orientation_transform` as the image coordinates are flipped compared to the microscope coordinates (for a detailed explanation see [this tutorial](https://mannlabs.github.io/py-lmd/html/pages/segmentation_loader.html#different-coordinate-systems))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -398,13 +425,44 @@
       "5% percentile vertices: 20\n",
       "Median vertices: 58\n",
       "95% percentile vertices: 97\n",
-      "Max vertices: 101\n",
-      "None\n"
+      "Max vertices: 101\n"
      ]
-    },
+    }
+   ],
+   "source": [
+    "orientation_transform = np.array(\n",
+    "    [\n",
+    "        [1, 0], \n",
+    "        [0, -1]\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "shape_collection = Collection(\n",
+    "    calibration_points=caliblist,\n",
+    "    orientation_transform=orientation_transform\n",
+    "    )\n",
+    "\n",
+    "# Load geopandas into collection class \n",
+    "shape_collection.load_geopandas(annotations)\n",
+    "\n",
+    "shape_collection.stats()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's inspect the loaded annotations and calibration points with the internal `plot` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAeMAAAHACAYAAACRTwCgAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAABN9ElEQVR4nO3deVwV9f7H8dcBDgdQ2QRZXHFJc19KxMqsUDS75a1MW0zNNE1vqV0rW8zslmmltljaonbL0rqZt1+ZiZY3S9Tc09SyVFIWV0Blh/n9MXH0BKgYMBx8Px+P8/DMzPec85mvB97MzHdmbIZhGIiIiIhlPKwuQERE5GKnMBYREbGYwlhERMRiCmMRERGLKYxFREQspjAWERGxmMJYRETEYgpjERERi3lZXUB1VFhYSFJSErVq1cJms1ldjoiIWMQwDE6cOEFkZCQeHqVv/yqMK0BSUhL169e3ugwREakifv/9d+rVq1fqcoVxBahVqxZgdr6/vz95eXksX76cnj17YrfbLa7OeuoPV+oPV+qP09QXrtyxPzIyMqhfv74zF0qjMK4ARbum/f39nWHs5+eHv7+/23yBKpL6w5X6w5X64zT1hSt37o9zHbLUAC4RERGLKYxFREQspjAWERGxmMJYRETEYgrjUsyaNYtGjRrh4+NDdHQ069evt7okERGpphTGJVi0aBHjxo3jqaeeYtOmTbRr1464uDgOHTpkdWkiIlINKYxLMH36dIYNG8aQIUNo2bIls2fPxs/Pj7lz51pdmoiIVEM6z/hPcnNz2bhxIxMmTHDO8/DwIDY2loSEhBJfk5OTQ05OjnM6IyMDMM+JK3oUTQvqjz9Rf7hSf5ymvnDljv1xvrUqjP/kyJEjFBQUEBYW5jI/LCyMXbt2lfiaKVOm8PTTTxebv3z5cvz8/JzT8fHx5Vusm1N/uFJ/uFJ/nKa+cOVO/ZGZmXle7RTG5WDChAmMGzfOOV10+bOePXs6r8AVHx9Pjx493O6qMRVB/eFK/eFK/XGa+sKVO/ZH0Z7Sc1EY/0lISAienp6kpqa6zE9NTSU8PLzE1zgcDhwOR7H5drvd5Qvz5+mLnfrDlfrDlfrjNPWFK3fqj/OtUwO4/sTb25tOnTqxcuVK57zCwkJWrlxJTEyMhZWJiEh1pS3jEowbN45BgwZx2WWX0blzZ2bOnMmpU6cYMmSI1aWJiEg1pDAuQf/+/Tl8+DATJ04kJSWF9u3bs2zZsmKDukRERMqDwrgUo0ePZvTo0VaXISIiFwEdMxYREbGYwlhERMRiCmMRERGLKYxFREQspjAWERGxmMJYRETEYgpjERERiymMRURELKYwFhERsZjCWERExGIKYxEREYspjEVERCymMBYREbGYwlhERMRiCmMRERGLKYxFREQspjAWERGxmMJYRETEYgpjERERiymMRURELKYwFhERsZjCWERExGIKYxEREYspjEVERCymMBYREbGYwlhERMRiCmMRERGLKYxFREQspjAWERGxmMJYRETEYgpjERERiymMRURELKYwFhERsZjCWERExGIKYxEREYspjEVERCymMBYREbGYwlhERMRiCmMpJiM7j+T0rBKXJadnkZGdV8kViYhUbwpjcZGRnceguevpP2ctSWmugZyUlkX/OWsZNHe9AllEpBwpjMXFqZx8jp7MJfFYJgPePB3ISWlZDHhzLYnHMjl6MpdTOfkWVyoiUn0ojMVFRIAvC4d3oUGwnzOQN+4/5gziBsF+LBzehYgAX6tLFRGpNhTGUkxkoGsg3/JGgksQRwYqiEVEypPCWEoUGejLjP7tXObN6N9OQSwiUgEUxlKipLQsxi7a6jJv7KKtxQZ1iYjIX6cwlmLOHKzVINiPT0bGuBxDViCLiJQvhbG4SE7PKjZYq1PD4GKDuko7D1lERMpOYSwuaji8qF3Tu9hgrTMHddWu6U0Nh5fFlYqIVB/6jSou/H3svHtPZ07l5Bc7fSky0JdF93WhhsMLfx+7RRWKiFQ/CmMpxt/HXmrY6vxiEZHyp93UIiIiFlMYi4iIWExhLCIiYjGFsYiIiMUUxiIiIhZTGIuIiFhMYSwiImKxahXGjRo1wmazuTyef/55lzbbtm3jqquuwsfHh/r16zNt2rRi7/Pxxx/TokULfHx8aNOmDUuXLq2sVRARkYtQtQpjgMmTJ5OcnOx8/OMf/3Auy8jIoGfPnjRs2JCNGzfywgsvMGnSJN58801nmzVr1nD77bczdOhQNm/eTN++fenbty/bt2+3YnVEROQiUO2uwFWrVi3Cw8NLXLZgwQJyc3OZO3cu3t7etGrVii1btjB9+nSGDx8OwMsvv0yvXr0YP348AM888wzx8fG89tprzJ49u9LWQ0RELh7VLoyff/55nnnmGRo0aMAdd9zB2LFj8fIyVzMhIYFu3brh7e3tbB8XF8fUqVM5fvw4QUFBJCQkMG7cOJf3jIuLY8mSJaV+Zk5ODjk5Oc7pjIwMAPLy8pyPomlB/fEn6g9X6o/T1Beu3LE/zrfWahXGDzzwAB07diQ4OJg1a9YwYcIEkpOTmT59OgApKSlERUW5vCYsLMy5LCgoiJSUFOe8M9ukpKSU+rlTpkzh6aefLjZ/+fLl+Pn5Oafj4+MveN2qI/WHK/WHK/XHaeoLV+7UH5mZmefVrsqH8aOPPsrUqVPP2mbnzp20aNHCZYu2bdu2eHt7c9999zFlyhQcDkeF1ThhwgSXz87IyKB+/fr07NkTf39/8vLyiI+Pp0ePHtjtutuR+sOV+sOV+uM09YUrd+yPoj2l51Llw/ihhx5i8ODBZ23TuHHjEudHR0eTn5/Pvn37aN68OeHh4aSmprq0KZouOs5cWpvSjkMDOByOEsPebre7fGH+PH2xU3+4Un+4Un+cpr5w5U79cb51VvkwDg0NJTQ09IJeu2XLFjw8PKhTpw4AMTExPP744+Tl5Tk7KD4+nubNmxMUFORss3LlSsaMGeN8n/j4eGJiYv7aioiIiJSi2pzalJCQwMyZM9m6dSu//fYbCxYsYOzYsdx1113OoL3jjjvw9vZm6NCh7Nixg0WLFvHyyy+77GJ+8MEHWbZsGS+99BK7du1i0qRJbNiwgdGjR1u1aiIiUs1V+S3j8+VwOFi4cCGTJk0iJyeHqKgoxo4d6xK0AQEBLF++nFGjRtGpUydCQkKYOHGi87QmgK5du/LBBx/wxBNP8Nhjj9GsWTOWLFlC69atrVgtERG5CFSbMO7YsSNr1649Z7u2bduyevXqs7bp168f/fr1K6/SREREzqra7KYWERFxVwpjERERiymMRURELKYwFhERsZjCWERExGIKYxEREYspjEVERCymMBYREbGYwlhERMRiCmMRERGLKYxFREQspjAWERGxmMJYRETEYgpjERERiymMRURELKYwFhERsZjCWERExGIKYxEREYspjEVERCymMBYREbGYwlhERMRiCmMRERGLKYxFREQspjAWERGxmMJYRETEYgpjERERiymMRURELKYwFhERsZjCWERExGIKYxEREYspjEVERCymMBYREbGYwlhERMRiCmMRERGLKYxFREQspjAWERGxmMJYRETEYgpjERERiymMRURELKYwFhERsZjCWERExGIKYxEREYspjEVERCymMBYREbGYwlhERMRiCmMRERGLKYxFREQspjAWERGxmMJYRETEYgpjERERiymMRURELKYwFhERsZjCWERExGIKYxEREYspjEVERCymMBYREbGYwlhERMRibhPGzz77LF27dsXPz4/AwMAS2yQmJtKnTx/8/PyoU6cO48ePJz8/36XNqlWr6NixIw6Hg6ZNmzJ//vxi7zNr1iwaNWqEj48P0dHRrF+/vgLWSERExORldQHnKzc3l379+hETE8M777xTbHlBQQF9+vQhPDycNWvWkJyczN13343dbue5554DYO/evfTp04cRI0awYMECVq5cyb333ktERARxcXEALFq0iHHjxjF79myio6OZOXMmcXFx7N69mzp16lTqOotIFXJwE7x1DdQMg46DwFELvP3AXuOMf2v8aZ6fOc/TbnX1UsW5TRg//fTTACVuyQIsX76cn376iRUrVhAWFkb79u155plneOSRR5g0aRLe3t7Mnj2bqKgoXnrpJQAuvfRSvvvuO2bMmOEM4+nTpzNs2DCGDBkCwOzZs/niiy+YO3cujz76aMWvqIhUTWteNf89mQrfTivbaz3sJYe03e8s82tg83BQK+tk+a+LVDluE8bnkpCQQJs2bQgLC3POi4uLY+TIkezYsYMOHTqQkJBAbGysy+vi4uIYM2YMYG59b9y4kQkTJjiXe3h4EBsbS0JCQqmfnZOTQ05OjnM6IyMDgLy8POejaFpQf/yJ+sNVVe0Pr9/XYfvjeUGHQdjyMqHokZv5x/QpyD0931b4x2GywjzITjcfZflM4Bps5OyqDy16lev6uKOq+t04m/OttdqEcUpKiksQA87plJSUs7bJyMggKyuL48ePU1BQUGKbXbt2lfrZU6ZMcW65n2n58uX4+fk5p+Pj48u2UtWc+sOV+sNVVeoPn7zj9MxIAiC+5YtkUgfsmI+zsBXm41WYg2dhjvPfM597FZQw74x2NXIOE5i1D69P72X1JU+Q4dug4lfWDVSl78a5ZGZmnlc7S8P40UcfZerUqWdts3PnTlq0aFFJFV2YCRMmMG7cOOd0RkYG9evXp2fPnvj7+5OXl0d8fDw9evTAbtexI/WHK/WHq6rYHx5rX8O23aCwXme6/31wpX1uXvYpDs/pRejJnXRPeoP8IcvNY9YXqar43TiXoj2l52JpGD/00EMMHjz4rG0aN258Xu8VHh5ebNRzamqqc1nRv0Xzzmzj7++Pr68vnp6eeHp6ltim6D1K4nA4cDgcxebb7XaXL8yfpy926g9X6g9XVao/tn8CgEe7AXhUak01+CHqAXonvYTt6B7sHw+EIV+C3acSa6h6qtR34xzOt05LT20KDQ2lRYsWZ314e3uf13vFxMTw448/cujQIee8+Ph4/P39admypbPNypUrXV4XHx9PTEwMAN7e3nTq1MmlTWFhIStXrnS2EZGLTOoOSP0RPL2h1d8r/ePzvGqQf9sH4BsMSZtgw9xKr0EqntucZ5yYmMiWLVtITEykoKCALVu2sGXLFk6eNEca9uzZk5YtWzJw4EC2bt3KV199xRNPPMGoUaOcW60jRozgt99+4+GHH2bXrl28/vrrfPTRR4wdO9b5OePGjeOtt97i3XffZefOnYwcOZJTp045R1eLyEVm60Lz32Y9wS/YmhqCG0PsU+bz76ZDjkZYVzduM4Br4sSJvPvuu87pDh06APDNN9/QvXt3PD09+fzzzxk5ciQxMTHUqFGDQYMGMXnyZOdroqKi+OKLLxg7diwvv/wy9erV4+2333ae1gTQv39/Dh8+zMSJE0lJSaF9+/YsW7as2KAuEbkIFBbAj/8xn7ftb20t7e+E72bC8b2wfg5c9ZC19Ui5cpswnj9/fqnnGBdp2LAhS5cuPWub7t27s3nz5rO2GT16NKNHjy5riSJS3exbDSeSwCcQLok7Z/MK5WmH7hPg0+Hw9b9g/dvgHwG1ih7h4B9p/lvrj399AsBmO/d7i+XcJoxFRCrd1kXmv63+Dl7FB2lWuja3mseMf19r/pFwIuns7e1+ruHsEt4R5nTN8It+QFhVoDAWESlJbibs/Mx8bvUu6iIenuZo6pOpcCL59CMjGU6k/BHQKZCRBNlp5sVHjv1mPs7GN/h0ONcKLx7YtSKgRqj5+VIhFMYiIiXZvRRyT0JgQ2jQxepqTvPwMAPSP+Ls7fKy/gjrP8L5RMqfwvuPR342ZB0zH4d2lP5+Nk8IawV/exnqdizfdRKFsYhIiYpGUbft757HXe2+5ijs4LNcq8EwzC3ojOQztqqTi291nzoERgGkbIN3ekLPf0H0fe7ZL1WUwlhE5M9OHoJfvzafV5Vd1BXBZgPfIPMR1rL0dgX5ZlgvmwC7Podlj5iD2256zXyt/GVuc56xiEil2f6JuSVYtxOENLW6Gut5ekFgA+j/PvR+wbwAyq7PYXY3OLDB6uqqBYWxiMifbftjFHXbAdbWUdXYbBA9HIYuh6AoSE+EuXHm7SUNw+rq3JrCWETkTId/hqTN4OEFrW+2upqqKbID3Pc/85SvwnxY/gR8OAAyj1ldmdtSGIuInGnbHwO3msZCjRBra6nKfALg1nnQZzp4OuDnZTD7KkhcZ3VlbklhLCJSpLAQtn1sPq/OA7fKi80Glw+Fe1dAcBPIOADzesN3M8y+lPOmMBaRMsvIziM5PavEZcnpWWRk51VyReUkMcE8Durwh+a9ra7GfUS0NXdbt+lnDnxbMQk+uA1OHbG6MrehMBaRMsnIzmPQ3PX0n7OWpDTXQE5Ky6L/nLUMmrvePQO5aBd1yxvN83Tl/Dlqwc1vwY2vgpcP7ImH2VfCvu+trswtKIxFpExO5eRz9GQuiccyGfDm6UBOSstiwJtrSTyWydGTuZzKybe40jLKy4Yd/zWfaxT1hbHZoOPdMOwbCLnEvGjIuzfAty9ot/U5KIxFpEwiAnxZOLwLDYL9nIG8cf8xZxA3CPZj4fAuRAS42ZblwQ2Qk27eOKHhFVZX497CWsLwVdDuDjAKzbtMvX+zeTEVKZHCWETKLDLQNZBveSPBJYgjA90siM/kqGVe/1n+Gu8a8Pc3oO8b5t2jfvvG3G392/+srqxK0jdORC5IZKAvM/q3c5k3o3879w1i7xrmv3mZ1tZR3bS/w9xtHXqpebepf98E30yBwgKrK6tSFMYickGS0rIYu2iry7yxi7YWG9TlNux/hHHuSWvrqI7qtIBhX0OHgYAB/3veDOUTKVZXVmUojEWkzM4crNUg2I9PRsa4HEN2y0Au2jLO1ZZxhfD2M28scfNb5h8++1abu62LbshxkVMYi0iZJKdnFRus1alhcLFBXaWdh1xlefuZ/xbmQX6utbVUZ21vg/u+hbA2cOowvHczrHzGvDPURUxhLCJlUsPhRe2a3sUGa505qKt2TW9qONzsDq1Fu6kB8k5ZV8fFIKQp3BsPl90DGLD6RXj3b5B+0OrKLFMuPy1paWkEBgaWx1uJSBXn72Pn3Xs6cyonv9jpS5GBviy6rws1HF74+9gtqvACeXmDh93cMs7N1H16K5rdF26YAY2uhM8ehMQ15m7rm9+EZj2srq7SlXnLeOrUqSxatMg5fdttt1G7dm3q1q3L1q1bz/JKEaku/H3spZ5HHBHg635BXKRoV3WutowrTetbzEtpRrSDrGOw4FaInwgFbngFt7+gzGE8e/Zs6tevD0B8fDzx8fF8+eWX9O7dm/Hjx5d7gSIilca7pvmvdlNXrtpNYGg8dL7PnP7+ZZjfB9J+t7auSlTmME5JSXGG8eeff85tt91Gz549efjhh/nhhx/KvUARkUpjL9oy1ojqSuflgOunwW3vgSMAfl9n7rbe/aXVlVWKModxUFAQv/9u/rWybNkyYmNjATAMg4ICncQtIm7MeXqTtowt0/JGGPEtRHaE7DT4cAB89Xi1H+Fe5jC++eabueOOO+jRowdHjx6ld2/zNmObN2+madOm5V6giEilcV6FS2FsqaBGcM9X0GWUOZ3wGszrBWn7LS2rIpU5jGfMmMHo0aNp2bIl8fHx1KxpHmNJTk7m/vvvL/cCRUQqjbaMqw4vb+j1HAz4EHwC4eBGvN6+hoi0DVZXViHKfGqT3W7nn//8Z7H5Y8eOLZeCREQso2PGVU+L62HEavjPPdgO/EDnva9Q8FUW9HrWPM5cTZxXGH/22Wf07t0bu93OZ599dta2N954Y7kUJiJS6bx1feoqKbABDPmSghVP45nwKp4b3oKDP0C/eRDc2OrqysV5hXHfvn1JSUmhTp069O3bt9R2NptNg7hExH3pzk1Vl6edwmufYn2qN12S52FL3gJzroYbX4FWf7e6ur/svMK4sLCwxOfingzDICUjm13JJ0g8lklqRjaZuQXkFRTi8PLE39eLiAAfokJq0iKilvtewEGkrLSbuso7FNCO/D6rsP/3PkhMgI8Hw97VEPcc2H2sLu+ClevFYzMzM/Hz8yvPt5Rykp1XwKrdh4n/KZXv9xwhJSP7vF97aYQ/3ZqF0LtNBO3qBWCz2SqwUhELFV30Q7upqzb/SBj0Oax6DlZPhw3vwMENMHAJ+AVbXd0FKXMYX3fddfz73/+mbt26LvPXrVvHwIED+fnnn8utOPnr9h89xfw1+/jPxgOcyD59VxRPDxtNQmsQFVKDcH8favp44eXhQW5BIWmZuRxMy2ZP6gmS0rPZmZzBzuQM5nz7G1EhNRjYpSG3XV6fmu52IwCRcym6HKZ2U1d9nl5w3URoeAUsHg7JW+H9W2DQZ+CoZXV1ZVbm36Y+Pj60bduW119/nf79+1NYWMjkyZN57rnndGpTFZKcnsX05T+zePNBCgoNACIDfLi+TQTdm9ehU8MgfL09z/k+h0/ksObXI6zYeYiVO1PZe+QUkz//iVe//oURVzdh8BWNcHid+31E3IJd16Z2O02vg8FfwLzekLQJPhgAd/3HvBGFGylzGH/xxRfMmjWLe+65h//+97/s27eP/fv38/nnn9OzZ8+KqFHKoKDQ4O3VvzFzxS9k5ZmD6a6+JJR7roziqqYheHiUbRdzaC0HN7Wvy03t63IqJ59PNx/kne/2svfIKaZ8uYsP1yfyr75tuLJZSEWsjkjlcu6mVhi7lTotYOBiePdG2P8dfHQ39F9gnqvsJi5oP+OoUaM4cOAAU6dOxcvLi1WrVtG1a9fyrk3K6PdjmYxZtIWN+48D0KlhEI/3uZSODcrnVnA1HF7c1aUhAy6vz6ebDzLtq93sO5rJXe+sY3DXRky4voW2ksW9aTe1+4rsAHd8BO/9HX5ZDouHwa1zwcM9fieV+Qpcx48f55ZbbuGNN95gzpw5zhtFvP766xVRn5yn7345wt9e+46N+49T0+HFtFva8p8RMeUWxGfy8vSg32X1+fqhqxnYpSEA89fso/+ctaSkn//AMJEqR1fgcm8NY2DAAvD0hp+WwP89AG5yBlCZw7h169akpqayefNmhg0bxvvvv88777zDk08+SZ8+fSqiRjmHTzYeYNC89aRl5tGuXgDLxlzFbZfXr/BRz7V87DzTtzXzBl9OgK+dLb+ncfPr37Pn0IkK/VyRCmNXGLu9ptfBLe+AzQM2vw9fPQaGYXVV51TmMB4xYgTffvstUVFRznn9+/dn69at5OZW77tqVEUL1u3noY+3UlBo0Ld9JIvui6FeUOWeXnZNizr83+graRJag6T0bPrNTmBXSkal1iBSLrRlXD20vBFu+mNv7bo3YNUUa+s5D2UO4yeffBIPj+Ivq1evHvHx8eVSlJyfxZsO8Pin2wEYemUU029rj4/dmuMjDWr78fGIrrSrF8DxzDzuensde4/oF5q4GR0zrj7a3w7Xv2g+/99U+P4Va+s5hzKHcZHMzEx27drFtm3bXB5SOdb8eoSH/2P295ArGvFEn0vLPFK6vAXX8Obf90TTKtKfIydzGTJvPcdPaW+JuBH7GZfDdJNjjXIWnYfBdU+Zz+OfhA3zrK3nLMocxocPH+aGG26gVq1atGrVig4dOrg8pOIlpWUxasEm8gsNbmgbwZN9WlaZq2IF+NmZP6QzdQN92Xc0kwcWbqawsOofrxEBTu+mBm0dVxdXjYMrx5nPPx8L2z62tp5SlDmMx4wZQ1paGuvWrcPX15dly5bx7rvv0qxZs3Pe0Un+uvyCQv7x4WaOZ+bRpm4AL/ZrZ/kW8Z+F1nIwd/Dl+Ng9WP3LEd74369WlyRyfuy+wB8/Twrj6uO6iXD5MMCAT++DXV9YXVExZQ7jr7/+munTp3PZZZfh4eFBw4YNueuuu5g2bRpTplT9g+Tu7u3v9rJx/3FqObyYdUdHy44Rn0vz8Fo8c1NrAGau+JmdyRrQJW7AZtNtFKsjmw16T4N2t4NRYN5c4tdvrK7KRZnD+NSpU9SpUweAoKAgDh8+DECbNm3YtGlT+VYnLvYfPcX0ePPa30/+rSUNalftm3Lc2qkePVuGkVdg8Ogn27S7WtyD7txUPXl4wI2vQYsboCAXFt4Bv6+3uiqnModx8+bN2b17NwDt2rVjzpw5HDx4kNmzZxMREVHuBcppz36xk9z8Qq5oWpt+nepZXc452Ww2/tW3NTUdXmw9kM5/Nh2wuiSRc9PpTdWXp5d5Va4m15qHIRbcCslVY+BxmcP4wQcfJDk5GYCnnnqKL7/8kgYNGvDKK6/w3HPPlXuBYtqw7xjLf0rF08PGpL+1qjIDts6ljr8PD17XDICXlu8m+4/rZYtUWUVhnKcwrpa8HND/fWgQA9np5uUzj/xidVVlD+O77rqLwYMHA9CpUyf279/PDz/8wO+//07//v3Luz75w4wV5u7p2y6rR7Mw97o92N1dGxIZ4ENqRg4L1ydaXY7I2VX33dT5ubBrKZw8bHUl1vGuAXcsgoh2kHkE/n0THN9vaUkXfJ4xwPfff4+npycdO3YkJER37ako2w+m8/2eo3h52Bh1TVOryykzh5cn9/9R91ur95JfoPM3pQqrzrupTx6Gf98IC2+HVzvB+reg8CLdW+UTAHd9CqEtIOOgGcgnUiwr5y+Fce/evTl48GB51SKlmL9mHwDXt4mo9EtdlpdbO9UjyM/OwbQsVu66iP8il6qvuu6mTt4Gb10DiQnmdE46LP0nvB0LSVssLc0yNWrDwCUQ1AiO74V/94XMY5aU8pfC2HCDi2+7u5M5+XyxzTxGP6hrQ4uruXA+dk8GdG4AwCeb9QecVGHVcct4x6cwNw7Sf4faTeH+ddD7BXD4Q9ImM6S/fASyL8JTEP0j4O7/Qq0IOLwT3r/Zkn74S2EsFe+r7Slk5RXQOKRGhdwOsTLd+scI8G9/OcrJPIuLESlNdTpmXFgI3zxnnleblwlNroN7V0CdFhA9HEb/AK1vAaMQ1s2G1y6H7Z+4xV2OylVQI3ML2a82JG2GDwdU+v9/mcN40KBBfPvttwDMmTOHsLCwci9KTlu2wzyGcWP7SLcZQV2aJqE1aV3Xn4JCg+3H3XtdpBqrLrupc07CRwPNmyQAxIyGOz4C3zP+qK8Vbp7qM/BTCG4MJ1PgP/eYW4dHL7Ir59VpAXctNvcW7P/e7Lv8yru2fpnDOD09ndjYWJo1a8bevXtJS0urgLIEIDuvgNW/mMdXe7YMt7ia8tHjUnM9th9TGEsVVR12U6f8CO/0gF2fg6c39H0D4p41z7MtSZNrYWQCdJ8Ang749Wt4PQZWPQ952ZVbu5Ui28OdH5t7R/asMI+pV5Iyh/GSJUs4ePAgI0eO5KOPPqJRo0b07t2b//znP+Tlad9jedqcmEZ2XiF1ajm4NMK9TmcqTffmoQDsybBRoCtySVXkzrup83PhmynwZnc49BPUDIPBS6H9Hed+rd0Huj8K9yeY4VyQY94H+I2uVe7SkRXGMCB1++nplMq7IMgFHTMODQ1l3LhxbN26lXXr1tG0aVMGDhxIZGQkY8eO5ZdfrD+BujpYv9cc1RfduLbb76Iu0irSnxoOT7IKbPycqmv/ShVUtGWctAkOutElfpO2mAOx/vc8FOabl328bzXUv7xs71O7ibm79ta5UDMcjv0K7/U1d19bfC5uhUo/aO6e/+Ih8/h6o6vgtn9X2sf/pQFcycnJxMfHEx8fj6enJ9dffz0//vgjLVu2ZMaMGeVVIwDPPvssXbt2xc/Pj8DAwBLb2Gy2Yo+FCxe6tFm1ahUdO3bE4XDQtGlT5s+fX+x9Zs2aRaNGjfDx8SE6Opr16625fumPB9MB6Ngg0JLPrwhenh60rRsAwPaki3DkplR9Ya0AGxzeZYbb/Bvg56+q7v2N83Ng5WR461pzq86vthmk/d+HWhc4psdmMwd2jV4P0SPA5mEO7Hq5HXx4O+xZWXX7o6wMA7YuMnfL//o1ePlAr6lw92cQ2KDSyihzGOfl5fHJJ59www030LBhQz7++GPGjBlDUlIS7777LitWrOCjjz5i8uTJ5Vpobm4u/fr1Y+TIkWdtN2/ePJKTk52Pvn37Opft3buXPn36cM0117BlyxbGjBnDvffey1dffeVss2jRIsaNG8dTTz3Fpk2baNeuHXFxcRw6dKhc1+d8FN3pqGWEf6V/dkVq+ccu950pJyyuRKQEDbvCiO/MO/x4eMG+1fDBbfBGDGx6zwy/quLARpjTDVa/ZN6NqNXfYdR6M0jLY2+aTwD0ngrDvjF3XWPA7qXmFuSsy2HtbPOSku7q1BFzoNanw83zrut2Mv/vu4wwbyxRiUo5ml+6iIgICgsLuf3221m/fj3t27cv1uaaa64pdev1Qj399NMAJW7JnikwMJDw8JIHO82ePZuoqCheeuklAC699FK+++47ZsyYQVxcHADTp09n2LBhDBkyxPmaL774grlz5/Loo4+W09qcW3ZeAUnpWQA0rVOz0j63MjQJNXcD7jvixgNkpHoLbw1/nw3XPmme8rNxvrml/Nlo+PoZiL4PLrvHdWRyZcrLMk9ZSnjNPC2pRij0eQla3lQxnxfZ3hxxfeQX+OFt2PIBHN0Dyx4xt8rb9TfvFxzWsmI+vyLs/Bz+70Hzcpgeduj+CFwxtvRBbhWszNE/Y8YMkpKSmDVrVolBDGYg7t2796/WdkFGjRpFSEgInTt3Zu7cuS4XJklISCA2NtalfVxcHAkJ5hVpcnNz2bhxo0sbDw8PYmNjnW0qy4HjWRgG1HR4EVzDu1I/u6LV/+MqYr8fz7K4EpFzCKgLPZ+BsduhxzNQKxJOppoBNL0VfPlo5R9HTVwHs6+ENa+YQdymn7k1XFFBfKaQZuaW8rid0Gc6hF5qngK2Ya6552D+DbBjCRRU4cG8WWnw6QhYdKcZxHVawbCvodt4y4IYLmDLeODAgRVRR7mYPHky1157LX5+fixfvpz777+fkydP8sADDwCQkpJS7LzosLAwMjIyyMrK4vjx4xQUFJTYZteuXaV+bk5ODjk5p3ddZWSYu5fz8vKcj6Lp85WSZm411qnlTX5+/nm/zh0E+3oCcORkjkbgwwV9P6qzKtkfnn7QeSR0GortpyV4rp2F7dAOWPcGxvo3MS69kYIuoyCifbl+rEtf5GXisepZPNa/iQ0Do2YYBb1fxLikd1Hjcv3ss/JwQPu7od1AbInf47FhLrbdX2Dbtxr2rcaoFUFhx8EUth8INeuU28f+1e+G7bdVeH7+ALYTSRg2Dwpj/kHhVQ+bd3KqoP4731qt+zMAePTRR5k6depZ2+zcuZMWLVqc1/s9+eSTzucdOnTg1KlTvPDCC84wrihTpkxx7kY/0/Lly/HzO30t6fj4+PN+zy1HbYAnRs4pli5dWh5lVhmn8gC8OJlTwGefL8VL14EDyvb9uBhU3f6oCZEPE1prB00PLaXOie3YfvoUj58+5XDNS9lT53oO+bcxBz2Vk02LX6V94tvUzDXHriQGX8n2uneSt8eAPVXg94Pvrfi0vJZGR76m4dFV+JxIxvN/U7B9O42DgZ3ZGxrLcb+m5XMcm7J/NzwLcmiVtJCoIysBOOkIY1OD4RzPagbLV5ZLTaXJzDy/U+QsDeOHHnrIeTvG0jRu3PiC3z86OppnnnmGnJwcHA4H4eHhpKamurRJTU3F398fX19fPD098fT0LLFNacehASZMmMC4ceOc0xkZGdSvX5+ePXvi7+9PXl4e8fHx9OjRA7vdfl6152xOgp+3Uy8shOuv71SGta76TmXn8NiG/wFwRffrqF3TYXFF1rqQ70d15j790Qd4mLzU7eaW8k+fEnpyJ6End2KENKegyyiMVreYW10XKO9UGinvj6DxkRUAGLUiKLh+BhFNY4kop7UoX3dBfg75u/4Pjw3v4HHwB+ofT6D+8QSM8LYUXHYvRsu/g933gt79Qr4btgPr8fxsFLbj5qHTgsvuxXHNk8QUncJWwYr2lJ6LpWEcGhpKaGhohb3/li1bCAoKwuEwfxhiYmKKbWXGx8cTExMDgLe3N506dWLlypXOUdiFhYWsXLmS0aNHl/o5DofD+RlnstvtLl+YP0+fTQHmX5AOu2cV/4VUdn5nHMc/kllAeFD1Wr8LVZbvx8XAbfqjXge49W1InwRr34CN72I7shuvzx+AVc/9MdhrSNkHe/22Cq///oPG6X/cA7zj3dh6/gsvn4ByX4VyZbdDh9vNR9JmWP82bP8PtpRtZp+sfAo6DITLh5rXhL6gjziP70Z+DnzzLKx51Ty27l8PbnoNzybX4HlBn3phzvc7bGkYl0ViYiLHjh0jMTGRgoICtmzZAkDTpk2pWbMm//d//0dqaipdunTBx8eH+Ph4nnvuOf75z9OXMxsxYgSvvfYaDz/8MPfccw9ff/01H330EV988YWzzbhx4xg0aBCXXXYZnTt3ZubMmZw6dco5urqyePyxN6c6Xq/9zHXy8qweFzMRIaCeecnJqx82R1+vnQ0nkmDl0+apRx3vhi4jz33uanYGxD8JG+djAzLttfG+dQ5ezXtUxlqUr8gO0HeWOQhu83vmSOy0RHPw2ZpX4ZI46DwMGl9bvqcSJW81B2kd+smcbncH9H7ePFWrinKbMJ44cSLvvvuuc7pDhw4AfPPNN3Tv3h273c6sWbMYO3YshmHQtGlT52lKRaKiovjiiy8YO3YsL7/8MvXq1ePtt992ntYE0L9/fw4fPszEiRNJSUmhffv2LFu2rNJviOH9x4HU3IJqcmL9Gc5cp7qBF7a7SqTK8gmAKx6E6JHmhTLWvAqHdsDa12HdHPNc4K7/ME8X+rM9K+CzByHjAAAFHYfwTX4XejbuXqmrUO78gs0+iRkNvyyH9W/Bryvh52XmI7iJGcrtbgffwAv/nIJ8+G7G6auQ1QiFv70MLfqU26pUFLcJ4/nz55/1HONevXrRq1evc75P9+7d2bx581nbjB49+qy7pStDLYe5ayMjqwqNKC0nGdnm6HAPG9TwdpuvoEjZeHlD+9uh3QAzeNa8Cr+tgu3/MR9R3aDrA9A01rxwxlePw5b3zdcGNoSbXqOwXgz51WkAp4cnNO9tPo7s+eOc5QXmJTeXPWqeMta2vxnMYa3K9t6Hf4ZP7zMvYwpw6d/ghplQI6TcV6Mi6DdhFRVc0zy3+MjJyruFV2U5dspcp0A/Ox4e2k0t1ZzNZgZu01hz9+ma18wt5r3fmo/aTc0wPnUYsJnHmK+baF4juyqd3lXeQpqau46vfQK2LTKD+dBPsHGe+Wh4hRnKLW4Az7Mcdy38417MK5+G/Gxzz8T1L5rnX7vRNf0VxlVURIAPAKkZ2eQXFOLlWX3O/zmYZl7sI9zfx+JKRCpZRDu45S0zbIuu7HV0j7ksuAncNAsaxlhaYqVz1DQHc112j3kf4fVvmlfH2v+9+agVAZ2GQKfB4BPs+trj+2HJ/bD/O3O6yXVw46vmxVrcjMK4igqr5YO3pwe5BYUkpWXToLbfuV/kJhKPmWFcP0jHi+UiFVjfHOzVbTzsWGzOazsAvKvPz3mZ2WzQ6ErzkX7Q/ENl4zw4kWyOSv/2BTwv/RtBua3MUaAb34WvHoPck2CvYQ4Su+wet9oaPpPCuIry8LDROLQGu1JOsCslo1qFcdGtE5uEVq9rbouUmW+gGSDiKqAuXPs4dPsn/PSZubV8YD0eOxbTjcUYr7xpXpYUoEEM9H0dgi/8mhRVQfXZ91kNtYw079ZU3W41uCOp6G5UtSyuRESqNC8HtO0H98bD8P9R2O5OCmx2bCdTwdPbvF744C/cPohBW8ZVWocGQSzedJCN+49ZXUq5ycjOY3eqeevEdvWr7jl/IlLFRLan4IaXiS/sSs8G+Xg16gqhl1hdVblRGFdhXaLMwQob9h0nO68AH3tlXjemYqz/7RiFBoT4GBrAJSJlludVC6P99eaVvqoR7aauwprWqUlEgA85+YWs+fWI1eWUi5W7zAvdNw+ohpcWExG5QArjKsxmsxF7qXnlr2XbUyyu5q/LLyhkxU5z0EWbYIWxiEgRhXEV16eteW+WL39MITuvwOJq/prv9hzh8IkcgvzsNPNXGIuIFFEYV3GdGwVTN9CXEzn5fLEt2epy/pJFP/wOwA1twnUPYxGRM+hXYhXn4WHjjmjzLi/z1uzFcNPbOB04nslXO8xd7QMur2dxNSIiVYvC2A3c3rkBDi8Pth/MYPUv7jmQ681vf6PQgCua1uaSMJ1fLCJyJoWxGwiu4c2d0Q0BmB7/s9ttHR9My2LhenMX9ahrmlpcjYhI1aMwdhMjujfG1+7Jlt/T+GxrktXllMnzX+4it6CQLo2D6drEPW5nJiJSmRTGbqJOLR/u794EgOeW7iQj2z1urbZmzxH+b2sSNhs80ael1eWIiFRJCmM3MqxbYxrV9iM1I4dnP99pdTnndConn4c/2QbAXdENaV1Xl78UESmJwtiN+Ng9mXZrO2w2WLTh9yp9qpNhGDy5ZDsHjmdRN9CXR3q3sLokEZEqS2HsZjpHBXNfN3N39SOfbOOXP266UNW8vy6RxZsP4ulhY0b/9tR06DLoIiKlURi7oX/2vITOUcGczMlnyPwfOHQi2+qSXKzafYhJn+0A4J89m9P5jxteiIhIyRTGbsjL04PZd3WiYW0/DhzPYuDb6zl2KtfqsgBY+9tRRry/kYJCg1s61mPE1e5/n1ERkYqmMHZTwTW8+fc9nQnzd7A79QQD3kwgOT3L0pq+2X2IIfN+IDuvkGuahzLl5jbYbDZLaxIRcQcKYzfWsHYNFtzbhTB/Bz+nnuTm19fw44H0Sq/DMAzeX7ufYe9uICuvgKsvCeWNuzrhrQtQi4icF/22dHNN69Tkk5FdaRxag+T0bG6ZvYb31u6vtKt0ncjO46GPt/LEku3kFxr0bR/JW3dfho/ds1I+X0SkOlAYVwP1gvz49P4ruK5FHXLzC3lyyXbunruevUdOVejnrtyZSq+Zq1m86SAeNni0dwtm9G+vLWIRkTLS+SbVRICvnbfuvox3E/bx/Je7WP3LEeJmfMudXRow8uom1PH3KbfP2vJ7Gi8t3+28aUX9YF+m39aeyxtp1LSIyIVQGFcjHh42hlwRRffmdZj02Q7+9/Nh5n2/jwVrE7mhXQQDLm/AZQ2D8PAo+6CqzNx84n9KZcHaRNbvOwaA3dPG0Csb849rm1JD5xGLiFww/QathqJCajB/yOV8t+cIM+J/ZlNiGos3HWTxpoOE+Tvo1iyU6Ma1aRXpT1RIjWLHdw3DICMrn58PnWDbgXQSfj3Cd3uOkJ1XCICnh42/d6jLP65tSsPaNaxYRRGRakVhXE3ZbDauahbKlU1D2PJ7GgvWJfLV9hRSM3L4eOMBPt54wNk2yM9OTR8v7J4e5OQVkpaZy6ncgmLv2SDYj74d6nJH5waEB5Tfbm8RkYudwrias9lsdGgQRIcGQfyrb2vW/naUNb8eZUtiGjuTMziRk8/xzDyOZxa/C1REgA+XRvjTOSqYK5uG0CrSX+cNi4hUAIXxRcTH7kn35nXo3rwOYO6OTs/KIzUjh1O5+eTlF+Jj96SWjxcRAb74euv0JBGRyqAwvojZbDYC/bwJ9PO2uhQRkYuaTggVERGxmMJYRETEYgpjERERiymMRURELKYwFhERsZjCWERExGIKYxEREYspjEVERCymMBYREbGYwlhERMRiCmMRERGLKYxFREQspjAWERGxmMJYRETEYgpjERERiymMRURELKYwFhERsZjCWERExGIKYxEREYspjEVERCymMBYREbGYwlhERMRiCmMRERGLKYxFREQspjAWERGxmFuE8b59+xg6dChRUVH4+vrSpEkTnnrqKXJzc13abdu2jauuugofHx/q16/PtGnTir3Xxx9/TIsWLfDx8aFNmzYsXbrUZblhGEycOJGIiAh8fX2JjY3ll19+qdD1ExGRi5tbhPGuXbsoLCxkzpw57NixgxkzZjB79mwee+wxZ5uMjAx69uxJw4YN2bhxIy+88AKTJk3izTffdLZZs2YNt99+O0OHDmXz5s307duXvn37sn37dmebadOm8corrzB79mzWrVtHjRo1iIuLIzs7u1LXWURELiKGm5o2bZoRFRXlnH799deNoKAgIycnxznvkUceMZo3b+6cvu2224w+ffq4vE90dLRx3333GYZhGIWFhUZ4eLjxwgsvOJenpaUZDofD+PDDD8+7tvT0dAMw0tPTDcMwjNzcXGPJkiVGbm5u2VaymlJ/uFJ/uFJ/nKa+cOWO/fHnPCiNl9V/DFyo9PR0goODndMJCQl069YNb29v57y4uDimTp3K8ePHCQoKIiEhgXHjxrm8T1xcHEuWLAFg7969pKSkEBsb61weEBBAdHQ0CQkJDBgwoMRacnJyyMnJcU5nZGQAkJeX53wUTQvqjz9Rf7hSf5ymvnDljv1xvrW6ZRjv2bOHV199lRdffNE5LyUlhaioKJd2YWFhzmVBQUGkpKQ4553ZJiUlxdnuzNeV1KYkU6ZM4emnny42f/ny5fj5+Tmn4+Pjz2f1LhrqD1fqD1fqj9PUF67cqT8yMzPPq52lYfzoo48yderUs7bZuXMnLVq0cE4fPHiQXr160a9fP4YNG1bRJZ6XCRMmuGxxZ2RkUL9+fXr27Im/vz95eXnEx8fTo0cP7Ha7hZVWDeoPV+oPV+qP09QXrtyxP4r2lJ6LpWH80EMPMXjw4LO2ady4sfN5UlIS11xzDV27dnUZmAUQHh5Oamqqy7yi6fDw8LO2OXN50byIiAiXNu3bty+1RofDgcPhKDbfbre7fGH+PH2xU3+4Un+4Un+cpr5w5U79cb51WhrGoaGhhIaGnlfbgwcPcs0119CpUyfmzZuHh4frQPCYmBgef/xx8vLynCsfHx9P8+bNCQoKcrZZuXIlY8aMcb4uPj6emJgYAKKioggPD2flypXO8M3IyGDdunWMHDnyL66tiIhIydzi1KaDBw/SvXt3GjRowIsvvsjhw4dJSUlxOY57xx134O3tzdChQ9mxYweLFi3i5Zdfdtl9/OCDD7Js2TJeeukldu3axaRJk9iwYQOjR48GwGazMWbMGP71r3/x2Wef8eOPP3L33XcTGRlJ3759K3u1RUTkIuEWA7ji4+PZs2cPe/bsoV69ei7LDMMAzFHPy5cvZ9SoUXTq1ImQkBAmTpzI8OHDnW27du3KBx98wBNPPMFjjz1Gs2bNWLJkCa1bt3a2efjhhzl16hTDhw8nLS2NK6+8kmXLluHj41M5KysiIhcdtwjjwYMHn/PYMkDbtm1ZvXr1Wdv069ePfv36lbrcZrMxefJkJk+eXNYyRURELohb7KYWERGpzhTGIiIiFlMYi4iIWExhLCIiYjGFsYiIiMUUxiIiIhZTGIuIiFhMYSwiImIxhbGIiIjFFMYiIiIWUxiLiIhYTGEsIiJiMYWxiIiIxRTGIiIiFlMYi4iIWExhLCIiYjGFsYiIiMUUxiIiIhZTGIuIiFhMYSwiImIxhbGIiIjFFMYiIiIWUxiLiIhYTGEsIiJiMYWxiIiIxRTGIiIiFlMYi4iIWExhLCIiYjGFsYiIiMUUxlKqjOw8ktOzSlyWnJ5FRnZeJVckIlI9KYylRBnZeQyau57+c9aSlOYayElpWfSfs5ZBc9crkEVEyoHCWEp0KiefoydzSTyWyYA3TwdyUloWA95cS+KxTI6ezOVUTr7FlYqIuD+FsZQoIsCXhcO70CDYzxnIG/cfcwZxg2A/Fg7vQkSAr9Wlioi4PYWxlCoy0DWQb3kjwSWIIwMVxCIi5UFhLGcVGejLjP7tXObN6N9OQSwiUo4UxnJWSWlZjF201WXe2EVbiw3qEhGRC6cwllKdOVirQbAfn4yMcTmGrEAWESkfCmMpUXJ6VrHBWp0aBhcb1FXaecgiInL+FMZSohoOL2rX9C42WOvMQV21a3pTw+FlcaUiIu5Pv0mlRP4+dt69pzOncvKLnb4UGejLovu6UMPhhb+P3aIKRUSqD4WxlMrfx15q2Or8YhGR8qPd1CIiIhZTGIuIiFhMYSwiImIxhbGIiIjFFMYiIiIWUxiLiIhYTGEsIiJiMYWxiIiIxRTGIiIiFlMYi4iIWExhLCIiYjGFsYiIiMUUxiIiIhZTGIuIiFhMYSwiImIxhbGIiIjF3CKM9+3bx9ChQ4mKisLX15cmTZrw1FNPkZub69LGZrMVe6xdu9blvT7++GNatGiBj48Pbdq0YenSpS7LDcNg4sSJRERE4OvrS2xsLL/88kulrKeIiFyc3CKMd+3aRWFhIXPmzGHHjh3MmDGD2bNn89hjjxVru2LFCpKTk52PTp06OZetWbOG22+/naFDh7J582b69u1L37592b59u7PNtGnTeOWVV5g9ezbr1q2jRo0axMXFkZ2dXSnrKiIiFx8vqws4H7169aJXr17O6caNG7N7927eeOMNXnzxRZe2tWvXJjw8vMT3efnll+nVqxfjx48H4JlnniE+Pp7XXnuN2bNnYxgGM2fO5IknnuCmm24C4N///jdhYWEsWbKEAQMGVNAaiojIxcwtwrgk6enpBAcHF5t/4403kp2dzSWXXMLDDz/MjTfe6FyWkJDAuHHjXNrHxcWxZMkSAPbu3UtKSgqxsbHO5QEBAURHR5OQkFBqGOfk5JCTk+OczsjIACAvL8/5KJoW1B9/ov5wpf44TX3hyh3743xrdcsw3rNnD6+++qrLVnHNmjV56aWXuOKKK/Dw8OCTTz6hb9++LFmyxBnIKSkphIWFubxXWFgYKSkpzuVF80prU5IpU6bw9NNPF5u/fPly/Pz8nNPx8fFlXNPqTf3hSv3hSv1xmvrClTv1R2Zm5nm1szSMH330UaZOnXrWNjt37qRFixbO6YMHD9KrVy/69evHsGHDnPNDQkJctnovv/xykpKSeOGFF1y2jivChAkTXD47IyOD+vXr07NnT/z9/cnLyyM+Pp4ePXpgt9srtBZ3oP5wpf5wpf44TX3hyh37o2hP6blYGsYPPfQQgwcPPmubxo0bO58nJSVxzTXX0LVrV958881zvn90dLTLX1Dh4eGkpqa6tElNTXUeYy76NzU1lYiICJc27du3L/VzHA4HDoej2Hy73e7yhfnz9MVO/eFK/eFK/XGa+sKVO/XH+dZpaRiHhoYSGhp6Xm0PHjzINddcQ6dOnZg3bx4eHuceCL5lyxaXUI2JiWHlypWMGTPGOS8+Pp6YmBgAoqKiCA8PZ+XKlc7wzcjIYN26dYwcOfL8V0xERKQM3OKY8cGDB+nevTsNGzbkxRdf5PDhw85lRVuz7777Lt7e3nTo0AGAxYsXM3fuXN5++21n2wcffJCrr76al156iT59+rBw4UI2bNjg3Mq22WyMGTOGf/3rXzRr1oyoqCiefPJJIiMj6du3b+WtsIiIXFTcIozj4+PZs2cPe/bsoV69ei7LDMNwPn/mmWfYv38/Xl5etGjRgkWLFnHrrbc6l3ft2pUPPviAJ554gscee4xmzZqxZMkSWrdu7Wzz8MMPc+rUKYYPH05aWhpXXnkly5Ytw8fHp+JXVERELkpuEcaDBw8+57HlQYMGMWjQoHO+V79+/ejXr1+py202G5MnT2by5MllLVNEROSCuMUVuERERKozhbGIiIjFFMYiIiIWUxiLiIhYTGEsIiJiMYWxiIiIxRTGIiIiFlMYi4iIWExhLCIiYjGFsYiIiMUUxiIiIhZTGIuIiFhMYSwiImIxhbGIiIjFFMYiIiIWUxiLiIhYTGEsIiJiMYWxiIiIxRTGIiIiFlMYi4iIWExhLCIiYjGFsYiIiMUUxiIiIhZTGIuIiFhMYSwiImIxhbGIiIjFFMYiIiIW87K6gOrIMAwAMjIyAMjLyyMzM5OMjAzsdruVpVUJ6g9X6g9X6o/T1Beu3LE/inKgKBdKozCuACdOnACgfv36FlciIiJVwYkTJwgICCh1uc04V1xLmRUWFpKUlEStWrWw2WxkZGRQv359fv/9d/z9/a0uz3LqD1fqD1fqj9PUF67csT8Mw+DEiRNERkbi4VH6kWFtGVcADw8P6tWrV2y+v7+/23yBKoP6w5X6w5X64zT1hSt364+zbREX0QAuERERiymMRURELKYwrgQOh4OnnnoKh8NhdSlVgvrDlfrDlfrjNPWFq+rcHxrAJSIiYjFtGYuIiFhMYSwiImIxhbGIiIjFFMYiIiIWUxhXglmzZtGoUSN8fHyIjo5m/fr1VpdU7iZNmoTNZnN5tGjRwrk8OzubUaNGUbt2bWrWrMktt9xCamqqy3skJibSp08f/Pz8qFOnDuPHjyc/P7+yV+WCfPvtt/ztb38jMjISm83GkiVLXJYbhsHEiROJiIjA19eX2NhYfvnlF5c2x44d484778Tf35/AwECGDh3KyZMnXdps27aNq666Ch8fH+rXr8+0adMqetUuyLn6Y/DgwcW+L7169XJpU136Y8qUKVx++eXUqlWLOnXq0LdvX3bv3u3Sprx+PlatWkXHjh1xOBw0bdqU+fPnV/Tqldn59Ef37t2LfT9GjBjh0qa69IeTIRVq4cKFhre3tzF37lxjx44dxrBhw4zAwEAjNTXV6tLK1VNPPWW0atXKSE5Odj4OHz7sXD5ixAijfv36xsqVK40NGzYYXbp0Mbp27epcnp+fb7Ru3dqIjY01Nm/ebCxdutQICQkxJkyYYMXqlNnSpUuNxx9/3Fi8eLEBGJ9++qnL8ueff94ICAgwlixZYmzdutW48cYbjaioKCMrK8vZplevXka7du2MtWvXGqtXrzaaNm1q3H777c7l6enpRlhYmHHnnXca27dvNz788EPD19fXmDNnTmWt5nk7V38MGjTI6NWrl8v35dixYy5tqkt/xMXFGfPmzTO2b99ubNmyxbj++uuNBg0aGCdPnnS2KY+fj99++83w8/Mzxo0bZ/z000/Gq6++anh6ehrLli2r1PU9l/Ppj6uvvtoYNmyYy/cjPT3dubw69UcRhXEF69y5szFq1CjndEFBgREZGWlMmTLFwqrK31NPPWW0a9euxGVpaWmG3W43Pv74Y+e8nTt3GoCRkJBgGIb5y9vDw8NISUlxtnnjjTcMf39/Iycnp0JrL29/Dp/CwkIjPDzceOGFF5zz0tLSDIfDYXz44YeGYRjGTz/9ZADGDz/84Gzz5ZdfGjabzTh48KBhGIbx+uuvG0FBQS798cgjjxjNmzev4DX6a0oL45tuuqnU11Tn/jh06JABGP/73/8Mwyi/n4+HH37YaNWqlctn9e/f34iLi6voVfpL/twfhmGG8YMPPljqa6pjf2g3dQXKzc1l48aNxMbGOud5eHgQGxtLQkKChZVVjF9++YXIyEgaN27MnXfeSWJiIgAbN24kLy/PpR9atGhBgwYNnP2QkJBAmzZtCAsLc7aJi4sjIyODHTt2VO6KlLO9e/eSkpLisv4BAQFER0e7rH9gYCCXXXaZs01sbCweHh6sW7fO2aZbt254e3s728TFxbF7926OHz9eSWtTflatWkWdOnVo3rw5I0eO5OjRo85l1bk/0tPTAQgODgbK7+cjISHB5T2K2lT13zV/7o8iCxYsICQkhNatWzNhwgQyMzOdy6pjf+hGERXoyJEjFBQUuHxhAMLCwti1a5dFVVWM6Oho5s+fT/PmzUlOTubpp5/mqquuYvv27aSkpODt7U1gYKDLa8LCwkhJSQEgJSWlxH4qWubOiuovaf3OXP86deq4LPfy8iI4ONilTVRUVLH3KFoWFBRUIfVXhF69enHzzTcTFRXFr7/+ymOPPUbv3r1JSEjA09Oz2vZHYWEhY8aM4YorrqB169YA5fbzUVqbjIwMsrKy8PX1rYhV+ktK6g+AO+64g4YNGxIZGcm2bdt45JFH2L17N4sXLwaqZ38ojKVc9O7d2/m8bdu2REdH07BhQz766KMq96UX6w0YMMD5vE2bNrRt25YmTZqwatUqrrvuOgsrq1ijRo1i+/btfPfdd1aXUiWU1h/Dhw93Pm/Tpg0RERFcd911/PrrrzRp0qSyy6wU2k1dgUJCQvD09Cw2KjI1NZXw8HCLqqocgYGBXHLJJezZs4fw8HByc3NJS0tzaXNmP4SHh5fYT0XL3FlR/Wf7HoSHh3Po0CGX5fn5+Rw7duyi6KPGjRsTEhLCnj17gOrZH6NHj+bzzz/nm2++cbnFann9fJTWxt/fv0r+QVxaf5QkOjoawOX7Ud36Q2Fcgby9venUqRMrV650zissLGTlypXExMRYWFnFO3nyJL/++isRERF06tQJu93u0g+7d+8mMTHR2Q8xMTH8+OOPLr+A4+Pj8ff3p2XLlpVef3mKiooiPDzcZf0zMjJYt26dy/qnpaWxceNGZ5uvv/6awsJC5y+imJgYvv32W/Ly8pxt4uPjad68eZXcJVsWBw4c4OjRo0RERADVqz8Mw2D06NF8+umnfP3118V2rZfXz0dMTIzLexS1qWq/a87VHyXZsmULgMv3o7r0h5PVI8iqu4ULFxoOh8OYP3++8dNPPxnDhw83AgMDXUYBVgcPPfSQsWrVKmPv3r3G999/b8TGxhohISHGoUOHDMMwT91o0KCB8fXXXxsbNmwwYmJijJiYGOfri05V6Nmzp7FlyxZj2bJlRmhoqNuc2nTixAlj8+bNxubNmw3AmD59urF582Zj//79hmGYpzYFBgYa//3vf41t27YZN910U4mnNnXo0MFYt26d8d133xnNmjVzOZUnLS3NCAsLMwYOHGhs377dWLhwoeHn51flTuUxjLP3x4kTJ4x//vOfRkJCgrF3715jxYoVRseOHY1mzZoZ2dnZzveoLv0xcuRIIyAgwFi1apXLqTqZmZnONuXx81F0Ks/48eONnTt3GrNmzaqSp/Kcqz/27NljTJ482diwYYOxd+9e47///a/RuHFjo1u3bs73qE79UURhXAleffVVo0GDBoa3t7fRuXNnY+3atVaXVO769+9vREREGN7e3kbdunWN/v37G3v27HEuz8rKMu6//34jKCjI8PPzM/7+978bycnJLu+xb98+o3fv3oavr68REhJiPPTQQ0ZeXl5lr8oF+eabbwyg2GPQoEGGYZinNz355JNGWFiY4XA4jOuuu87YvXu3y3scPXrUuP32242aNWsa/v7+xpAhQ4wTJ064tNm6datx5ZVXGg6Hw6hbt67x/PPPV9YqlsnZ+iMzM9Po2bOnERoaatjtdqNhw4bGsGHDiv2BWl36o6R+AIx58+Y525TXz8c333xjtG/f3vD29jYaN27s8hlVxbn6IzEx0ejWrZsRHBxsOBwOo2nTpsb48eNdzjM2jOrTH0V0C0URERGL6ZixiIiIxRTGIiIiFlMYi4iIWExhLCIiYjGFsYiIiMUUxiIiIhZTGIuIiFhMYSwiluvevTtjxoyxugwRy+iiHyJiuWPHjmG326lVq5bVpYhYQmEsIiJiMe2mFhGnw4cPEx4eznPPPeect2bNGry9vYvdAafIDz/8QI8ePQgJCSEgIICrr76aTZs2OZevWrUKb29vVq9e7Zw3bdo06tSp47zF3Z93U7/++us0a9YMHx8fwsLCuPXWW8t5TUWqFoWxiDiFhoYyd+5cJk2axIYNGzhx4gQDBw5k9OjRXHfddSW+5sSJEwwaNIjvvvuOtWvX0qxZM66//npOnDgBnA7agQMHkp6ezubNm3nyySd5++23CQsLK/Z+GzZs4IEHHmDy5Mns3r2bZcuW0a1btwpdbxGraTe1iBQzatQoVqxYwWWXXcaPP/7IDz/8gMPhOK/XFhYWEhgYyAcffMANN9wAQG5uLtHR0VxyySVs376dK664gjfffNP5mu7du9O+fXtmzpzJ4sWLGTJkCAcOHNAxZLloaMtYRIp58cUXyc/P5+OPP2bBggU4HA4SExOpWbOm81G0Kzs1NZVhw4bRrFkzAgIC8Pf35+TJkyQmJjrfz9vbmwULFvDJJ5+QnZ3NjBkzSv3sHj160LBhQxo3bszAgQNZsGABmZmZFb7OIlbysroAEal6fv31V5KSkigsLGTfvn20adOGyMhItmzZ4mwTHBwMwKBBgzh69Cgvv/wyDRs2xOFwEBMTQ25urst7rlmzBjBHTh87dowaNWqU+Nm1atVi06ZNrFq1iuXLlzNx4kQmTZrEDz/8QGBgYIWsr4jVtJtaRFzk5ubSuXNn2rdvT/PmzZk5cyY//vgjderUKbF9rVq1eP311xk4cCAAv//+Ow0aNGDGjBnOQVm//vor7du355VXXmHRokXk5uayYsUKPDzMnXNn7qb+s1OnThEYGMiiRYu4+eabK2SdRaymLWMRcfH444+Tnp7OK6+8Qs2aNVm6dCn33HMPn3/+eYntmzVrxnvvvcdll11GRkYG48ePx9fX17m8oKCAu+66i7i4OIYMGUKvXr1o06YNL730EuPHjy/2fp9//jm//fYb3bp1IygoiKVLl1JYWEjz5s0rbJ1FrKZjxiLitGrVKmbOnMl7772Hv78/Hh4evPfee6xevZo33nijxNe88847HD9+nI4dOzJw4EAeeOABl63oZ599lv379zNnzhwAIiIiePPNN3niiSfYunVrsfcLDAxk8eLFXHvttVx66aXMnj2bDz/8kFatWlXMSotUAdpNLSIiYjFtGYuIiFhMYSwiImIxhbGIiIjFFMYiIiIWUxiLiIhYTGEsIiJiMYWxiIiIxRTGIiIiFlMYi4iIWExhLCIiYjGFsYiIiMUUxiIiIhb7fwDTDvKa0QMvAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAeMAAAHACAYAAACRTwCgAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAR4ZJREFUeJzt3Qd0FNXbBvAnvUFCAgESIIEA0nsNIKLSsWBBiiJFacInCIKgFMGCgDSVKoINBZGif0SkK0jvgoAgnZBQk0BC+n7nvcMuuylAMMnsbJ7fOXN2Z3eymb0sefbeucXJZDKZQERERLpx1u9XExERkWAYExER6YxhTEREpDOGMRERkc4YxkRERDpjGBMREemMYUxERKQzhjEREZHOXPU+AUeUlpaGiIgIFCxYEE5OTnqfDhER6UTm1bpx4waCg4Ph7Jx1/ZdhnAskiEuVKqX3aRARkZ04d+4cSpYsmeXzDONcIDVic+H7+voiOTkZa9asQcuWLeHm5ob8juVhi+Vhi+VxB8vC+OURGxurKmfmXMgKwzgXmJumJYjNYezt7a3uG+UDlJtYHrZYHrZYHnewLBynPO51yZIduIiIiHTGMCYiItIZw5iIiEhnDGMiIiKdMYyzMGPGDJQuXRqenp5o0KABdu7cqfcpERGRg2IYZ2Lx4sUYPHgwxowZg71796JGjRpo1aoVLl26pPepERGRA2IYZ2LKlCno1asXevTogcqVK2P27NmqO/38+fP1PjUiInJAHGecTlJSEvbs2YMRI0ZYHpMpzJo3b45t27Zl+jOJiYlqsx7kbR4TZ97M+3SnHFgeGpaHLZbHHSwL45fH/Z4rwzidK1euIDU1FcWKFbN5XPaPHj2a6c+MHz8eY8eOzfC4zBQjNWqztWvX5sIZGxfLwxbLwxbL4w6WhXHLIz4+/r6OYxjnAKlFyzXm9NOfyZRt5hm45MPTokULw80akxtYHrZYHrZYHnewLIxfHuaW0nthGKdTpEgRuLi4ICoqyuZx2S9evHimP+Ph4aG29OTDYv2BSb+f37E8bLE8bLE87mBZGLc87vc82YErHXd3d9SpUwfr16+3WRJR9sPDw3U9NyIickysGWdCmpy7deuGunXron79+pg2bRri4uJU72oiIqKcxjDORMeOHXH58mWMHj0akZGRqFmzJlavXp2hUxcREVFOYBhnYcCAAWojIiLKbbxmTEREpDOGMRERkc4YxkRERDpjGBMREemMYUxERKQzhjEREZHOGMZEREQ6YxgTERHpjGFMRESkM4YxERGRzhjGREREOmMYExER6YxhTEREpDOGMRERkc4YxkRERDpjGBMREemMYUxERKQzhjEREZHOGMZEREQ6YxgTERHpjGFMRESkM4YxERGRzhjGREREOmMYExER6YxhTEREpDOGMRERkc4YxkRERDpjGBMREemMYUxERKQzhjEREZHOGMZEREQ6YxgTERHpjGFMRESkM4YxERGRzhjGREREOmMYExER6YxhTEREpDOGMRERkc4YxpRBbEIyLsbcyvQ5eVyeJyKinMMwJhsStN3m70THOdsREW0byLIvj8vzDGQiopzDMCYbcYkpuHozCWevxaPT3DuBLLeyL4/L83IcERHlDIYx2Qjy88Ki3g0REuBtCeQ9Z65Zglgel+flOCIiyhkMY8oguJBtID83a5tNEMvzRESUcxjGlCkJ3Kkda9g8JvsMYiKinMcwpkzJNeI3Fh+weUz203fqIiKi/45hTBlYd9aSpuml/cJtriEzkImIchbDmDKMI07fWatOaECGTl1ZjUMmIqLsYxiTDR8PVxQu4J6hs5Z1py55Xo4jIqKcwb+oZMPX0w1f9ayvxhGnH74kgby4T0MVxHIcERHlDIYxZSBBm1XYcnwxEVHOYzM1ERGRzhjGREREOmMYExER6YxhTEREpDOGMRERkc4YxkRERDpjGBMREenMocK4dOnScHJystk++ugjm2MOHjyIhx9+GJ6enihVqhQmTpyY4XWWLFmCihUrqmOqVauGVatW5eG7ICKi/MahwliMGzcOFy9etGz/93//Z3kuNjYWLVu2RGhoKPbs2YNJkybh3Xffxdy5cy3HbN26FZ07d8Yrr7yCffv2oX379mo7dOiQTu+IiIgcncPNwFWwYEEUL1480+cWLlyIpKQkzJ8/H+7u7qhSpQr279+PKVOmoHfv3uqY6dOno3Xr1hg6dKjaf++997B27Vp89tlnmD17dp6+FyIiyh8cLoylWVoCNCQkBF26dMEbb7wBV1ftbW7btg1NmzZVQWzWqlUrTJgwAdevX4e/v786ZvDgwTavKcesWLEiy9+ZmJioNusauEhOTrZs5n26Uw4sDw3LwxbL4w6WhfHL437P1aHC+PXXX0ft2rUREBCgmptHjBihmqql5isiIyNRpkwZm58pVqyY5TkJY7k1P2Z9jDyelfHjx2Ps2LEZHl+zZg28vb0t+1LDpjtYHrZYHrZYHnewLIxbHvHx8Y4RxsOHD1c117s5cuSI6nBlXaOtXr26qgH36dNHhaWHh0eunaOEvvXvlpqxdA6T69O+vr7qm5F8eFq0aAE3N652xPKwxfKwxfK4g2Vh/PIwt5QaPoyHDBmC7t273/WYsLCwTB9v0KABUlJScPr0aVSoUEFdS46KirI5xrxvvs6c1TFZXYcWEvSZhb18WKw/MOn38zuWhy2Why2Wxx0sC+OWx/2ep92HcWBgoNoehHTOcnZ2RtGiRdV+eHg43nnnHfXtylxA8i1LglqaqM3HrF+/HoMGDbK8jhwjjxMREeUGhxnaJB2vpk2bhgMHDuDkyZOq57R03nrppZcsQSsduqTpWoYtHT58GIsXL1a9p62bmAcOHIjVq1dj8uTJOHr0qBr6tHv3bgwYMEDHd0dERI7M7mvG90uaiRctWqTCU3o2S0ctCWProPXz81Odqvr37486deqgSJEiGD16tGVYk2jUqBG+++47jBw5Em+//TbKly+velJXrVpVp3dGRESOzmHCWHpRb9++/Z7HSceuzZs33/WYDh06qI2IiCgvOEwzNRERkVExjImIiHTGMCYiItIZw5iIiEhnDGMiIiKdMYyJiIh0xjAmIiLSGcOYiIhIZwxjIiIinTGMiYiIdMYwJiIi0hnDmIiISGcMYyIiIp0xjImIiHTGMCYiItIZw5iIiEhnDGMiIiKdMYyJiIh0xjAmIiLSGcOYiIhIZwxjIiIinTGMiYiIdMYwJiIi0hnDmIiISGcMYyIiIp0xjImIiHTGMCYiItIZw5iIiEhnDGMiIiKdMYyJiIh0xjAmIiLSGcOYiIhIZwxjIiIinTGMiYiIdMYwJiIi0hnDmIiISGcMYyIiIp0xjImIiHTGMCYiItIZw5iIiEhnDGMiIiKdMYyJiIh0xjAmIiLSGcOYiIhIZwxjIiIinTGMiYiIdMYwJiIi0hnDmIiISGcMYyIiIp0xjImIiHTGMCYiItIZw5iIiEhnDGMiIiKdMYyJiIh0xjAmIiLSGcOYiIhIZwxjIiIinRkmjD/44AM0atQI3t7eKFSoUKbHnD17Fu3atVPHFC1aFEOHDkVKSorNMZs2bULt2rXh4eGBcuXK4csvv8zwOjNmzEDp0qXh6emJBg0aYOfOnbn2voiIiFxhEElJSejQoQPCw8PxxRdfZHg+NTVVBXHx4sWxdetWXLx4ES+//DLc3Nzw4YcfqmNOnTqljunbty8WLlyI9evX49VXX0VQUBBatWqljlm8eDEGDx6M2bNnqyCeNm2aeu7YsWMq4Ikon7qwF/j8UaBAMaB2N8CjIODuDbj5WN1a35dbb+0xFze9z57snGHCeOzYseo2s5qsWLNmDf7++2+sW7cOxYoVQ82aNfHee+/hrbfewrvvvgt3d3cVsGXKlMHkyZPVz1SqVAlbtmzB1KlTLWE8ZcoU9OrVCz169FD78jO//PIL5s+fj+HDh+fZ+yUiO7P1U+32ZhTwx8Ts/ayzW+YhrW6zetwHTs4eKHjrZq68HbIvhgnje9m2bRuqVaumgthMArZfv344fPgwatWqpY5p3ry5zc/JMYMGDbLUvvfs2YMRI0ZYnnd2dlY/Iz+blcTERLWZxcbGqtvk5GTLZt6nO+XA8tCwPIxRHq7ndsDp9v3UWt3glBwPmLek+Nv7ceq++XGntNuXydKSgYQYbcvO7wTwKJyQeLQUULE18rtkO/1s3M39nqvDhHFkZKRNEAvzvjx3t2MkPG/duoXr16+r5u7Mjjl69GiWv3v8+PGWmnv62rpcvzZbu3btA747x8TysMXysN/y8Ey+jpaxEer+2sofIx5FAWl5vkfrs4Sxa1oiXNISLbfW911TM3nM6jifxMsodOs0XJe/is0PjUSsV0jevGE7t9aOPhv3Eh8fb/9hLM2+EyZMuOsxR44cQcWKFWHPpCYt15nNJNxLlSqFli1bwtfXV30zkg9PixYt1DXs/I7lYYvlYf/l4bz9MzgdMiGtZH00e6Z7nv3e5IQ4XJ7TGoE3j6BZxCyk9FijXbPOp5Lt8LNxL+aWUrsO4yFDhqB797t/sMPCwu7rtaTjVvpez1FRUZbnzLfmx6yPkcD08vKCi4uL2jI7xvwamZGe2bKlJx8W6w9M+v38juVhi+Vhx+VxaKm6ca7RCc55ek4+2FXmdbSJmAynqyfgtqQr0ONXwM0T+ZmbPX027uF+z1PXoU2BgYGq1nu3TTpe3Q/pZf3XX3/h0qVLlsfkG5QEbeXKlS3HSA9qa3KMPC7kd9WpU8fmmLS0NLVvPoaI8pmow0DUX4CLO1DlmTz/9cmuPkh54TvAKwCI2Avsnp/n50C5zzDjjGUM8f79+9WtXNeV+7LdvKn1NJQmYQndrl274sCBA/jtt98wcuRI9O/f31JrlSFNJ0+exLBhw9Q14JkzZ+KHH37AG2+8Yfk90tz8+eef46uvvlJN5NIBLC4uztK7mojymQOLtNvyLQHvAH3OISAMaD5Gu79lCpDIHtaOxjAduEaPHq0C0kx6R4uNGzeiWbNmqnl55cqVKjylFuvj44Nu3bph3Lhxlp+RYU0yTEnCd/r06ShZsiTmzZtnGdYkOnbsiMuXL6vfJx2+ZIjU6tWrM3TqIqJ8IC0V+OtH7X71jvqeS80XgS3TgOungJ1zgIeH6Hs+lD/DWMYXZzXG2Cw0NBSrVq266zES3Pv27bvrMQMGDFAbEeVzpzcDNyIAz0LAQ3e+tOtCJg5pNgJY3hvY8D6wcx7gGwQUNG/FAd9g7bbg7VtPP8DJPCCL7JlhwpiIKM8dWKzdyrVi14ydNPNctee1a8bntmtfEmS7G5k8xDqcbcI7SNsvUDzfdwizBwxjIqLMyOQdR362jyZqM2cXrTe1zAJ24+KdLVZuI28HdCQgY6ITorXJR66d1La7kc5h5nBW4Z0usOXWJ1D7/ZQrGMZERJk5tgpIugkUCgVCGsJuODtrASnb3STfuh3Wt8NZhbV1eN/eUhKAW9e07dLhrF/PyQUoVgV4cjpQonaOv638jmFMRHS3XtRSKzbidVc3L60XtmxZMZm0GrQKZ3Ot2iqozcEddwkwpQKRB4EvWgIt3wca9DFmudgphjERUXo3LwH/brCvJurcIGHq5a9txbT5GDKVmqKF9eoRwNGVwOq3tM5tT3+m/Szln3HGRER5OuOW1ARL1AGKlNP7bPTn4goUCgE6fgu0maRNgCKhPLspcH633mfnEBjGRETpHbzdi7p6J73PxP5q0g16A6+sAfzLADFngfmttOUlpcmbHhjDmIjI2uV/gIh9gLMrUPVZvc/GPgXXAvr8rg35kmUi14wEvu8ExF/T+8wMi2FMRGTt4O2OW+WaAz5F9D4b+yUTijy/AGg3BXDxAP5ZDcx+GDi7Q+8zMySGMRGRWVoacHCJ43fcyslm63qvAK+uAwLKArHngQVtgC1TtbKk+8YwJqJsi01IxsWYW5k+J4/L84Z0dpt2HdTDF6jQRu+zMY6g6lqzdbUOWse3de8C370AxF3R+8wMg2FMRNkiQdtt/k50nLMdEdG2gSz78rg8b8hANjdRV35KG6dL98+jIPDs58BTnwKunsCJtcDsJsDpP/U+M0NgGBNRtsQlpuDqzSScvRaPTnPvBLLcyr48Ls/LcYaSnAAc/km7z17UD95sXftloNdGoMhD2qQhXz0B/DGJzdb3wDAmomwJ8vPCot4NERLgbQnkPWeuWYJYHpfn5ThDubAbSIzRFk4Ibaz32RibTCDSexNQowtgStNWmfr2WW0yFcoUw5iIsi24kG0gPzdrm00Qy/OGbm6V+Z/pv3H3AZ6ZBbSfpa0edXKj1mx98ne9z8wu8RNHRA9EAndqxxo2j8m+YYNYwkPISkeUc2p20ZqtAytpq019/TSwcTyQlqr3mdkVhjERPRC5RvzG4gM2j8l++k5dhuF2O4xlpSbKWUUrAr02ALW6yuoUwO8faaEsC1OQwjAmomyz7qwlTdNL+4XbXEM2ZCCba8ayjjHlPHdvbWEJ6XEtX3xkoQlptjYvyJHPMYyJKFtkHHH6zlp1QgMydOrKahyyXYeFSEsGUpL0PhvHVf0FoM8fQLFqQNxl4JtngfXvaStD5WMMYyLKFh8PVxQu4J6hs5Z1py55Xo4zZDO1SI7T80wcn6yE9epaoG5Prdl688fAV08CMReQX+XI/5bo6GgUKlQoJ16KiOycr6cbvupZX40jTj98SQJ5cZ+GKojlOENxdQec3bSasTRVc53e3CWTqjwxFSjdBPh5IHB2q9Zs/excoHwL5DfZrhlPmDABixffXl4MwAsvvIDChQujRIkSOHDAtjMHETkmCdqsxhHL44YL4vRN1UmsGeeZqs9pU2kG1QBuXQMWPg+sHQ2kGnAGt7wM49mzZ6NUqVLq/tq1a9X266+/ok2bNhg6dGhunCMRUd5wL6Ddspk6bxUuC7yyFqjfR9v/czrwZTsg+hzyi2yHcWRkpCWMV65cqWrGLVu2xLBhw7Br167cOEciorwhk1MI9qjOe64eQNuJwAvfAB5+wLkdWrP1sV+RH2Q7jP39/XHunPZtZfXq1WjevLm6bzKZkJrKQdxEZGCW4U2sGeum8lNA3z+A4NpAQjTwfSfgt3ccvod7tsP42WefRZcuXdCiRQtcvXpVNU+Lffv2oVy5crlxjkREeTwLF8NYV/6lgZ6/AQ37a/vbPgMWtAaiz8BRZTuMp06digEDBqBy5crqenGBAto1losXL+K1117LjXMkIsobrBnbV+/21h8Cnb4HPAsBF/bAdd6jCIreDUeU7aFNbm5uePPNNzM8/sYbb+TUORER6YPXjO1PxbZA383Ajz3hdH4X6p/6BKm/3QJaf6BdZ85PYfzzzz+r5mgJYrl/N0899VROnRsRkU41Y85PbVcKhQA9fkXqurFw2fYpXHZ/DlzYBXRYAASEId+Ecfv27VUv6qJFi6r7WXFycmInLiIyLq7cZL9c3JD22BjsjHJHw4sL4HRxPzDnEeCpT4AqzyBfhHFaWlqm98mYpOd7ZGwCjl68oeYRjopNQHxSKpJT0+Dh6gJfL1cE+XmiTJECqBhU0LgTOBBlF5up7d4lvxpIabcJbj/1Ac5uA5Z0B05tBlp9CLh5wqhydPLY+Ph4eHvf/jCTXUlITsWmY5ex9u8o/Hniigrj+1UpyBdNyxdBm2pBqFHST7WAEDn0pB9sprZvvsFAt5XApg+BzVOA3V8AF3YDXVcA3gHIF2H8+OOP4+uvv1bTX1rbsWMHunbtin/++Scnz4/+ozNX4/Dl1tP4cc953Ei4syqKi7MTygb6oEwRHxT39UQBT1e4OjsjKTUN0fFJuBCdgBNRNxARk4AjF2PVNuePk+r4rg1D8UK9UihgtIUAiO53Okw2U9s/F1fg8dFAaGNgWW/g4gHg2+eAbj8DHgVhNNn+a+rp6Ynq1atj5syZ6Nixo2q2HjduHD788EMObbIjsnzdlDX/YNm+C0hNM6nHgv080bZaEJpVKIo6of7wcne55+tcvpGIrf9ewbojl7D+SBROXYnDuJV/49MNx9H3kbLo3ri0atomcqxmag5tMoxyjwPdfwEWtAEi9gLfdQJe+lFbiMKRw/iXX37BjBkz0LNnT/z00084ffo0zpw5o6bGlGkxSV8SvPM2n8S0dcdxK1nrTPfIQ4Ho2aQMHi5XBM7O2WtiDizogadrllCbrNKzfN8FfLHllArl8b8exfc7z+L99tXQpHyRXHpHRHo0UzOMDaVoRaDrMuCrp4AzW4AfXgY6LtTGKhvEA7Uz9u/fH+fPn1crOLm6umLTpk1o1KhRzp8dZcu5a/EYtHg/9py5rval9vtOu0qoHZIzS8HJsngvNQxFp3qlVChP/O0YTl+Nx0tf7ED3RqUxom1F1pLJ2NhMbVzBtYAuPwDfPAMcXwMs6wU8Px9wdnHMGbiuX7+O5557DrNmzcKcOXMsC0VIszXpZ8vxK3jysy0qiOVa7sTnquPHvuE5FsTWXF2c0aFuKWwY8oi6fizkunTHOdsRGXP/HcOI7A5n4DK20HCg00LAxR34ewXwv9dlCBAcMoyrVq2KqKgoNRd1r1698O233+KLL77AqFGj0K5du9w5S7qrpXvOo9uCnYiOT1a9nVcPelh1sMrtXs8FPd3wXvuqWNC9Hvy83LD/XDSenfknTly6kau/lyjXuDGMHeIa8nNfAE7OwL5vgd/elvGccLgw7tu3L/744w+UKVPG8ph05Dpw4ACSkhx7VQ17tHDHGQxZckBdK25fMxiL+4SjpH/eDi97tGJR/G9AE9U7W3pfd5i9DUcjY/P0HIhyBGvGjrPy09O3W2t3zAI2jYfDhbHUgJ2dM/5YyZIl1cIRlHeW7T2Pd5YfUvdfaVIGU16oCU83fa6PhBT2xpK+jVTN/Hp8Ml6at0N18iIyFF4zdhw1OwNtP9bu/z4B+PMTOFQYW0/wcfToURw8eNBmo7whw42G/aiVd4/GpTGyXaVs95TOaQE+7vi6ZwNUCfbFlZtJ6LFgJ67HsbWEDNhMLWFskGuNdBf1ewGPj9Hurx0F7F4Ahwnjy5cv44knnkDBggVRpUoV1KpVy2aj3BcRfQv9F+5FSpoJT1QPwqh2le1mViw/bzd82aM+ShTyUj2tX1+0D2m3xzkTGaaZWrB27BgeHgw0GazdX/kGcHAJHCKMBw0ahOjoaDXjlpeXF1avXo2vvvoK5cuXv+eKTvTfpaSm4f++36eagquV8MPHHWroXiPObGzy/O714OnmjM3Hr2DW7//qfUpE90dNFHH7/xPD2HE8Phqo10tm5geW9wGO/gLDh/GGDRswZcoU1K1bV107Dg0NxUsvvYSJEydi/Hj7v0hudPO2nFLDlwp6uGJGl9q6XSO+lwrFC+K9p6uq+9PW/aOm0ySye9LCxGUUHfPftc1EoEZnwJSqLS7x70YYOozj4uLUUorC399fNVuLatWqYe/evTl/hmQzz/SUtdrc36OerKw6Tdmz5+uURMvKxZCcasLwpQfZXE3GwJWbHJOzM/DUZ0DFJ4DUJGBRF+DcThg2jCtUqIBjx46p+zVq1FATf1y4cAGzZ89GUFBQbpwj3fbBL0eQlJKGxuUKo0OdkrB3ch37/fZV1SQkB87H4Me95/U+JaJ74/Amx15c4vn5QNnHtMsQC58HLh40ZhgPHDgQFy9eVPfHjBmDX3/9FSEhIfjkk0/UYhGUO3afvoY1f0ep1ZbefbKK3XTYupeivp4Y+Hh5dX/ymmNqKUciQ4RxMsPYIbl6AB2/BULCgYQYbfrMK8eNF8Zyfbh79+7qfp06ddQiEbt27cK5c+fU5B+UO6au05qnX6hbEuWLGWt5sJcbhaoVo6JiE7Fo51m9T4cofzdTpyQBR1cBN7VLjPn2C1eXxUBQDSD+CvD108D1M8YcZyz+/PNPuLi4oHbt2ihShKv25JZDF2Lw54mrcHV2Qv9Hy8FoZPGI126f9+ebT6ke4UR2y5GbqSWAv34KWNQZ+LQOsPNzIC2ftlZ5+gEvLQcCKwKxF7RAvhFpzDBu06aNul5MuUsWYRCyFnFeT3WZk525/L3dcCH6FtYfzcffyMn+OWoztVwb/fxR4Ow2bT8xBlj1JjCvORCxH/mST2Gg6wrAvzRw/RTwdXsg/prxwthkgMm3je5mYgp+Oahdo+/WSFshyYhkCFan+iHq/tJ9/AJHdswRa8aHlwPzWwEx54DC5YDXdgBtJgEevkDEXi2kf30LSMiHQxB9g4CXfwIKBgGXjwDfPqtLOfynMKbc99uhSNxKTkVYEZ9cWQ4xr2vH4o/jV3EzWe+zIcoH14xlSs+NH2rjaqX3cNnHgVfXAUUrAg16AwN2AVWfA0xpwI7ZwGf1gENLDbHKUY6SmrHUkL0LAxH7gO875fm/f7bDuFu3bmrVJiHDmooVK5Yb50W3rT6sXcN4qmawYXpQZ6VsYAFULeGrVpg6dN3Y74UcmKM0UyfeBH7oqi2SIMIHAF1+ALysvtQXLK4N9em6HAgIA25GAj/21GqHV/PZzHlFKwIvLdNaC878qZWddHaz1zCOiYlB8+bN1fSXp06dUlNjUu6QYUCbj2vXV1tWLg5H0KKS9j4OXWMYk51yhGbqyL+AL1oAR1cCLu5A+1lAqw+0cbaZkXG3/bYBzUYALh7AvxuAmeHApo+A5ATkG8E1gReXaK0jJ9Zp19TtNYxXrFihOm3169cPP/zwA0qXLq06cv34449ITmbbY07adzYaCclpKFrQA5WCjDWcKSvNKgSq2xOxTqqGTGR3jNxMLTW5jeOBuc2AS38DBYoB3VcBNbvc+2fdPIFmw4HXtmnhnJqorQM8q5HdTR2Za6R5PkpbllaJPGjf14wDAwMxePBgHDhwQC0YUa5cOXTt2hXBwcF44403cPy4/gOoHcHOU1qvvgZhhQ3fRG0myyv6eLjgVqoT/oni3L9kxzVj6dh0wUBT/EqPaOmI9ftHQFqKNu1jn81AqXrZe53CZbXmWmm+LlAcuPYv8E17rfla57G4uSrmgtY8/8sQ7fp66YeBF76GITpwyUxca9euVZuMN27bti3++usvVK5cGVOnTs3ZqSA/+ACNGjWCt7c3ChUqlOkxEljpt0WLFtkcs2nTJjUu2sPDQ32J+PLLLzO8zowZM1SN39PTEw0aNMDOnfrMX/rXhRh1Wzsk8/drRK4uzqhewk/dPxSRD3tukv0rVkVbuenyUS3cvnwC+Oc3+13fOCURWD8O+PwxrVYnnZAkSGWWqYIP2KdHvvxLx64BO4EGfQEnZ61j1/QawPedgRPr7bc8HqQ2fGCx1iwvzfOunkDrCcDLPwOFtBEgdhnG0hS9dOlStaaxrNi0ZMkStaxiRESEWkpx3bp1qvl63LhxOXqiSUlJ6NChg2oev5sFCxaoLwnmrX379pbn5Bp3u3bt8Oijj2L//v3qvF999VX89ttvlmMWL16sav0y1acsfCHzb7dq1QqXLl1CXjOvdFQ5yBeOpPLtJvcjkTf0PhWijEIbAX23aCv8OLsCpzcD370AzAoH9n6jhZ+9OL8HmNMU2DxZW42oyjNA/51akOZEa5pMjNFmAtBro9Z0LUsQHlul1SBn1AO2z9amlDSquCtaR63lvbVx1yXqaP/2DftqC0vkoSyu5mdNFoNIS0tD586dVY2xZs2aGY6RsMuq9vqgxo4dq24zq8lak99bvHjmnZ1kMYsyZcpg8uTJar9SpUrYsmWLqsVL4ApZHrJXr17o0aOH5Wd++eUXzJ8/H8OHD0dedt6KiLml7pcrWgCOpGyg1gx4+oqBO8iQYyteFXhmNvDYKG3Iz54vtZryzwOADe8BDfoAdXva9kzOS8m3tCFL2z7ThiX5BALtJgOVn869jk3S41rmcN41D9j/HXD1BLD6La1WXqOjtl5wscowjCMrgf8N1KbDdHYDmr0FNH4j605uuSzb0S/BJbVgacrNLIjNgSi1UD30799fTc1Zv359FaDWE5Ns27ZN9QS3JiEsj5tr33v27LE5RtZsln3zMXnl/PVbqvVEVjwK8HGHIyl1exaxc9e1LxtEdsuvBNDyPeCNQ0CL94CCwcDNKC2AplQBfh2e99dRz+4AZjcBtn6iBXG1DlptOLeC2FqR8lpNefARoN0UILCSNgRs93yt5UCa9A+vAFLtuDPvrWhgeV9g8YtaEBetAvTaADQdqlsQi2z/ZumoZa+kafyxxx5T15XXrFmD1157DTdv3sTrr7+uno+MjMwwLlr2Y2NjcevWLVy/fh2pqamZHnP06NEsf29iYqLazOT1zE365s28f78io7VaY9GC7khJSYEjCfByUbdXbiayB77V54JlYcfl4eIN1O8H1HkFTn+vgMv2GXC6dBjYMQumnXNhqvQUUhv2B4Iyr6DkSFkkx8N50wdw3jkXTjDBVKAYUtt8DNNDbcwHI884ewA1XwZqdIXT2T/hvHs+nI79Aidp0j+9GaaCQUir3R1pNbsCBYrazWfD6eQmuKx8HU43ImByckZa+P8h7eFh2kpOuVR+93uu+n0NAFSz74QJtwekZ+HIkSOoWLHifb3eqFGjLPdr1aqFuLg4TJo0yRLGuWX8+PGWZnRr8oVAvhiYSUe3+7X/qlzvcYEpMQ6rVq2CI4lTn01X3ExMxc8rV8GV88Bl+/ORH9hveRQAgochsOBhlLu0CkVvHILT38vh/PdyXC5QCSeKtsUl32pap6ccsnfZp6h5dh4KJGl9V84GNMGhEi8i+YQJOGEHfx+8nodn5cdQ+soGhF7dBM8bF+Hy+3g4/TERFwrVx6nA5rjuXS5nrmMj+58Nl9REVIlYhDJX1qv9mx7FsDekN67fKg+s0R7LLfHx8fYfxkOGDLEsx5iVsLCwB3596Qn93nvvqVqr9J6Wa8lRUVE2x8i+r68vvLy8VI9w2TI7Jqvr0GLEiBGq05d1zbhUqVJo2bKlem35ZiQfnhYtWsDNze2+zj1xXwTwzyGULFYEbdvWgSOJS0jE27t/V/cbN3schQt4ID97kM+HIzNOebQDMAzJUYe0mvLfyxF484jaTEUqqJqyqcpzWq3rASXHRSPy274Iu7JO7UuNM7XtVASVa44g2KOXVAe3lKP/g/PuL+B8YRdKXd+mNlPx6kit+ypMlZ8B3Lzy7LPhdH4nXH7uDydZCAJQ5+Dx6CiEm4ew5TJzS6ldh7GMV5Ytt0iPaX9/fxXEIjw8PEMtU/5h5XHh7u6u1mhev369pRe2dFaT/QEDBmT5e+T1zb/DmnxYrD8w6ffvJlWGVshru7nY+R+k7PO2uo5/JT4Vxf0d6/09qOx8PvIDw5RHyVrA8/OAmHeB7bOAPV/B6coxuK58Hdj04e3OXj2y39nr5Ca4/vR/CIu5vQZ47Zfh1PJ9uEoPZ3sm/2a1OmubzPO8cx5w6Ec4RR7UymT9GKBWV6DeK9qc0Ln12UhJBDZ+AGz9VLu27lsSePozuJR9FNqFsrxxv59hXcM4O86ePYtr166pW7muK0ErZKxwgQIF8L///U/VYBs2bKjGB0vIfvjhh3jzzTvTmfXt2xefffYZhg0bhp49e2LDhg1qGJb0ljaTGq7Mv123bl3VCWzatGmqudvcuzqvON9uzXHE+dqt35Ori2NMZkIEv5LalJOPDNN6X8uwnxsRwPqx2tCj2i8DDfvde+yqrBi0dpR6DfnfEe9WGO7Pz4FrhRYwnOBaQPsZWie4fd9oPbGjz2qdzyQkH2oF1O8FhD2Ws0OJLh7QOmnJLGSiRhegzUfaUC07ZZgwHj16tBrHbH1NWGzcuBHNmjVT3z6kh7fMACY9qCWkzcOUzGRYkwSvHDN9+nSULFkS8+bNswxrEh07dsTly5fV75MOX9JjfPXq1Xm+IIb77QupSakOMrDeivV7KlHowZqriOyW/MFvPBBo0E+bKENCRzp7bZ8J7JijjQVu9H/acKH0ZD7knwcCsefVbmrtHtiY0hAtw5rB0LwDtDKRxSqOrwF2fg78ux74Z7W2BZTVQlnGdnv9h2GxqSnAlql3ZiGTIV9PTgcqyiUF+2aYMJbxxXcbY9y6dWu13YsE9759++56jDRJ361ZOi8U9NCaNmJv2VGP0hwSm5Biqf37uBvmI0iUPa7uQM3OQI1OWvBIKJ/cpJps1VamKdDodaBcc23ijN/eAfZ/q/1soVDVpJpWMhwpjtSB09kFqNBG266cuD1meaE25ebq4dqQseodtWBWM6Flw+V/gOV9tGlMRaUngSemAT5FYAT8S2inAgpoY4uv3My7JbzyyrU47T0V8naDs7k9nshRSQ9iCVzZpPl062dajfnUH9pWuJwWxnGyQpuTdo358dHaHNn2NLwrpxUppzUdPzYSOLhYC2ZpVt6zQNtCG2uhLHNsu9zluqtMyykTs8jlgJQErWWi7cfa+GsDzenPMLZTQX6e6jYqNgEpqWlqTmdHcSFam+yjuK/2HonyjaAawHOfa2FrntlLZrIS0lT79AwgVOtQmm94FNA6c8mMZrKO8M652uxYcl+2gkFAnR5Ane6AZ4Dtz8qEKyteA85s0fbLPg489ak2WYvBMIztVLGCnnB3cVbXVyOiExBS+M54ZaM7e00L41L+vF5M+VShUlpnL5n16fAy7bHqnQB3x/l/nm1OTkDpJtomKyjJFxWpId+4qPVK/2MSXCo9Cf+kKlov0D1fAb+9DSTdBNx8tE5iEugGqg1bYxjbKWm+DQv0wdHIGzgaGetQYWxeOrFsoGPNuU2UbdJZSQKEbEnN9rF3gKZvAn//rNWWz++E8+FlaIplMH0yV5uWVISEA+1nAgEPPieFPXCctk8HVDnY1yGXGjx8+/2YV28iIsqUTJhSvQPw6lqg9+9Iq/EiUp3c4CRB7OKuzRfe/RfDB7FgzdiO1Qrxx7K9F7DnzDU4itiEZByL0pZOrFHKfsf8EZGdCa6J1CemY21aI7QMSYFr6UZA4ENwFAxjO9awjNZZYffp62pJRU+3vJw3JnfsPHkNaSagiKeJHbiIKNuSXQvCVLOtNtOXA2EztR2TdYylV3ViShq2/nsFjmD9UW2i+wp+Dji1GBHRA2IY2zEnJyc0r6TN/LX6UCSMToZorTuidbqoFsAwJiIyYxjbuXbVtbVZfv0rUjVVG9mWE1dw+UYi/L3dUN6XYUxEZMYwtnP1Sweo+ZtvJKbgl4MXYWSLd51Tt09UK841jImIrPBPogHGG3dpoK3ysmDrKbUIhhGdvx6P3w5rTe2d6pXU+3SIiOwKw9gAOtcPgYerMw5diMXm48bsyDX3j5OqF3XjcoXxUDGOLyYissYwNoAAH3e82CBU3Z+y9h/D1Y5lLupFO7Um6v6PltP7dIiI7A7D2CD6NguDl5sL9p+Lxs8HImAkH/16VM2x3TAsAI3KGmM5MyKivMQwNoiiBT3xWrOy6v6Hq46omayMYOuJK/jfgQg1d/vIdpX1Ph0iIrvEMDaQXk3DULqwN6JiE/HByiOwd3GJKRi29KC6/1KDUFQtwekviYgywzA2EJkOc+LzNVQtc/Huc3Y91Emua49acQjnr99SQ7PealNR71MiIrJbDGODqV8mAH2aas3Vby09iOO3F12wN9/uOItl+y7AxdkJUzvWRAEPToNORJQVhrEBvdnyIRXKNxNT0OPLXbh0IwH2ZNOxS3j358Pq/pstK6hzJSKirDGMDcjVxRmzX6qD0MLeqhm467yduBaXBHuw/eRV9P12D1LTTHiudkn0fcT464wSEeU2hrGBxx5/3bM+ivl6qPWBO83dhosxt3Q9p43HLqHHgl1ISE7DoxUCMf7ZamqxCyIiujuGsYGFFvbBwlcbqkD+J+omnp25FX+dj9Gls9a328+g11e7cSs5FY88FIhZL9WBOyegJiK6L/xraXCy5vHSfo0QFuiDizEJeG72Vnyz/UyezdJ1IyEZQ5YcwMgVh5CSZkL7msH4/OW6quc3ERHdH4axAyjp743lrzXG4xWLIiklTQ0penn+Tpy6Eperv3f9kSi0nrYZy/ZegLMTMLxNRdVzmjViIqLs4XgTB+Hn5aZqpF9tO62mn5QFJVpN/QMvNgxBv0fKoqivZ479LpmSc/KaY5ZFK0oFeGHKCzVRrzR7TRMRPQiGsYMtt9ijcRk0q1BUDS36/Z/LWPDnaSzcfhZP1AhCp3ohqBvqr47LrvikFKz9O0q91s7T19Rjbi5OeKVJGP7vsXLw4ThiIqIHxr+gDqhMER982aMetpy4gqlr/8Hes9GqKVk26ezVtHwgGoQVRpVgX3Vs+uu7cr059lYK/rl0AwfPx2Dbv1fUa0kvaSETeTxTq4QKYelERkRE/w3D2EHJkKKHyweiSbkiqll54Y6z+O1QpJrXesme82oz8/d2QwFPV7i5OCMxOQ3R8UmIS0rN8JohAd5oX6sEutQPQXG/nGv2JiLK7xjG+SCUa4X4q+399lXVpBxb/72K/WejceRiLG4kpuB6fLLa0gvy80SlIF81g5aEutSkOW6YiCjnMYzzEWmOluvJspmbo2NuJavaclxSCpJT0tQxBT1dEeTnBS93Dk8iIsoLDON8TGq5hbzd1UZERPrhgFAiIiKdMYyJiIh0xjAmIiLSGcOYiIhIZwxjIiIinTGMiYiIdMYwJiIi0hnDmIiISGcMYyIiIp0xjImIiHTGMCYiItIZw5iIiEhnDGMiIiKdMYyJiIh0xjAmIiLSGcOYiIhIZwxjIiIinTGMiYiIdMYwJiIi0hnDmIiISGcMYyIiIp0xjImIiHTGMCYiItIZw5iIiEhnDGMiIiKdGSKMT58+jVdeeQVlypSBl5cXypYtizFjxiApKcnmuIMHD+Lhhx+Gp6cnSpUqhYkTJ2Z4rSVLlqBixYrqmGrVqmHVqlU2z5tMJowePRpBQUHqdzVv3hzHjx/P9fdIRET5lyHC+OjRo0hLS8OcOXNw+PBhTJ06FbNnz8bbb79tOSY2NhYtW7ZEaGgo9uzZg0mTJuHdd9/F3LlzLcds3boVnTt3VsG+b98+tG/fXm2HDh2yHCMB/sknn6jX37FjB3x8fNCqVSskJCTk+fsmIqJ8wmRQEydONJUpU8ayP3PmTJO/v78pMTHR8thbb71lqlChgmX/hRdeMLVr187mdRo0aGDq06ePup+WlmYqXry4adKkSZbno6OjTR4eHqbvv//+vs8tJibGJEUrtyIpKcm0YsUKdUssj/RYHrZYHnewLIxfHunzICuuMKiYmBgEBARY9rdt24amTZvC3d3d8pjUaCdMmIDr16/D399fHTN48GCb15FjVqxYoe6fOnUKkZGRqmnazM/PDw0aNFA/26lTp0zPJTExUW3WtXSRnJxs2cz7dKccWB4aloctlscdLAvjl8f9nqshw/jEiRP49NNP8fHHH1sekxCVa8rWihUrZnlOwlhuzY9ZHyOPm4+z/rnMjsnM+PHjMXbs2AyPr1mzBt7e3pb9tWvXZvOdOjaWhy2Why2Wxx0sC+OWR3x8vP2H8fDhw1XN9W6OHDmiOlyZXbhwAa1bt0aHDh3Qq1cv2IMRI0bY1LilZiwdyOQatq+vr/pmJB+eFi1awM3NDfkdy8MWy8MWy+MOloXxy8PcUmrXYTxkyBB07979rseEhYVZ7kdERODRRx9Fo0aNbDpmieLFiyMqKsrmMfO+PHe3Y6yfNz8mvamtj6lZs2aW5+jh4aG29OTDYv2BSb+f37E8bLE8bLE87mBZGLc87vc8dQ3jwMBAtd0PqRFLENepUwcLFiyAs7NtR/Dw8HC888476puT+c3LN6gKFSqoJmrzMevXr8egQYMsPyfHyONCmrklkOUYc/jKtxrpVd2vX78ce99ERESGG9okQdysWTOEhISo68SXL19W13Ctr+N26dJFdd6SYUsy/Gnx4sWYPn26TfPxwIEDsXr1akyePFkNl5KhT7t378aAAQPU805OTiqo33//ffz888/466+/8PLLLyM4OFgNgSIiIsoNhujAJbVX6bQlW8mSJTNM0mHu9Swdpvr3769qz0WKFFGTd/Tu3dtyrDRvf/fddxg5cqQao1y+fHnVk7pq1aqWY4YNG4a4uDj1c9HR0WjSpIkKcJkkhIiIKN+GsVxXvte1ZVG9enVs3rz5rsdIxy/ZsiK143HjxqmNiIgoLxiimZqIiMiRMYyJiIh0xjAmIiLSGcOYiIhIZwxjIiIinTGMiYiIdMYwJiIi0hnDmIiISGcMYyIiIp0xjImIiHTGMCYiItIZw5iIiEhnDGMiIiKdMYyJiIh0xjAmIiLSGcOYiIhIZwxjIiIinTGMiYiIdMYwJiIi0hnDmIiISGcMYyIiIp0xjImIiHTGMCYiItIZw5iIiEhnDGMiIiKdMYyJiIh0xjAmIiLSGcOYiIhIZwxjIiIinTGMKUuxCcm4GHMr0+fkcXmeiIj+O4YxZUqCttv8neg4Zzsiom0DWfblcXmegUxE9N8xjClTcYkpuHozCWevxaPT3DuBLLeyL4/L83IcERH9NwxjylSQnxcW9W6IkABvSyDvOXPNEsTyuDwvxxER0X/DMKYsBReyDeTnZm2zCWJ5noiI/juGMd2VBO7UjjVsHpN9BjERUc5hGNNdyTXiNxYfsHlM9tN36iIiogfHMKYsWXfWkqbppf3Cba4hM5CJiHIGw5iyHEecvrNWndCADJ26shqHTERE949hTJny8XBF4QLuGTprWXfqkuflOCIi+m/4l5Qy5evphq961lfjiNMPX5JAXtynoQpiOY6IiP4bhjFlSYI2q7Dl+GIiopzDZmoiIiKdMYyJiIh0xjAmIiLSGcOYiIhIZwxjIiIinTGMiYiIdMYwJiIi0hnDmIiISGcMYyIiIp0xjImIiHTGMCYiItIZw5iIiEhnDGMiIiKdMYyJiIh0xjAmIiLSGcOYiIhIZ4YI49OnT+OVV15BmTJl4OXlhbJly2LMmDFISkqyOcbJySnDtn37dpvXWrJkCSpWrAhPT09Uq1YNq1atsnneZDJh9OjRCAoKUr+refPmOH78eJ69VyIiyn8MEcZHjx5FWloa5syZg8OHD2Pq1KmYPXs23n777QzHrlu3DhcvXrRsderUsTy3detWdO7cWQX7vn370L59e7UdOnTIcszEiRPxySefqNffsWMHfHx80KpVKyQkJOTZ+yUiovzFFQbQunVrtZmFhYXh2LFjmDVrFj7++GObYwsXLozixYtn+jrTp09XrzN06FC1/95772Ht2rX47LPPVPhKrXjatGkYOXIknn76aXXM119/jWLFimHFihXo1KlTrr5PIiLKnwwRxpmJiYlBQEBAhsefeuopVYt96KGHMGzYMLVvtm3bNgwePNjmeKn1StCKU6dOITIyUjVNm/n5+aFBgwbqZ7MK48TERLWZxcbGqtvk5GTLZt6nO+XA8tCwPGyxPO5gWRi/PO73XA0ZxidOnMCnn35qUysuUKAAJk+ejMaNG8PZ2RlLly5VTdAStOZAlqCVWq412ZfHzc+bH8vqmMyMHz8eY8eOzfD4mjVr4O3tbdmXWjjdwfKwxfKwxfK4g2Vh3PKIj4+3/zAePnw4JkyYcNdjjhw5ojpcmV24cEE1NXfo0AG9evWyPF6kSBGbWm+9evUQERGBSZMm2dSOc8OIESNsfrfUjEuVKoWWLVvC19dXfTOSD0+LFi3g5uaG/I7lYYvlYYvlcQfLwvjlYW4pteswHjJkCLp3737XY+T6sJmE66OPPopGjRph7ty593x9aV62/gYl15KjoqJsjpF98zVm8608Jr2prY+pWbNmlr/Hw8NDbenJh8X6A5N+P79jedhiedhiedzBsjBuedzveeoaxoGBgWq7H1IjliCW3tELFixQTdH3sn//fptQDQ8Px/r16zFo0CDLYxLW8riQoVMSyHKMOXzlW430qu7Xr98DvEMiIiIHuWYsQdysWTOEhoaq68SXL1+2PGeuzX711Vdwd3dHrVq11P6yZcswf/58zJs3z3LswIED8cgjj6hry+3atcOiRYuwe/duSy1bxiVLUL///vsoX768CudRo0YhODhYXX8mIiLKt2EstVfptCVbyZIlbZ6T4UhmMlTpzJkzcHV1VdeZFy9ejOeff97yvDRvf/fdd2rokoxRlsCVDl5Vq1a1HCM9sOPi4tC7d29ER0ejSZMmWL16tZokhIiIKN+GsVxXvte15W7duqntXqTjl2xZkdrxuHHj1EZERJQXDDEDFxERkSNjGBMREemMYUxERKQzhjEREZHOGMZEREQ6YxgTERHpjGFMRESkM4YxERGRzhjGREREOmMYExER6YxhTEREpDOGMRERkc4YxkRERDpjGBMREemMYUxERKQzhjEREZHOGMZEREQ6YxgTERHpjGFMRESkM4YxERGRzhjGREREOmMYExER6YxhTEREpDOGMRERkc4YxkRERDpjGBMREemMYUxERKQzV71PwBGZTCZ1Gxsbq26Tk5MRHx+v9t3c3JDfsTxssTxssTzuYFkYvzzMOWDOhawwjHPBjRs31G2pUqX0PhUiIrKTXPDz88vyeSfTveKasi0tLQ0REREoWLAgnJyc1DcjCeZz587B19cX+R3LwxbLwxbL4w6WhfHLQyJWgjg4OBjOzllfGWbNOBdIgZcsWTLD4/LhMcoHKC+wPGyxPGyxPO5gWRi7PO5WIzZjBy4iIiKdMYyJiIh0xjDOAx4eHhgzZoy6JZZHeiwPWyyPO1gW+ac82IGLiIhIZ6wZExER6YxhTEREpDOGMRERkc4YxkRERDpjGOeBGTNmoHTp0vD09ESDBg2wc+dOOJp3331XzTZmvVWsWNHyfEJCAvr374/ChQujQIECeO655xAVFWXzGmfPnkW7du3g7e2NokWLYujQoUhJSYER/PHHH3jyySfVLDvy3lesWGHzvPSTHD16NIKCguDl5YXmzZvj+PHjNsdcu3YNL774oprMoFChQnjllVdw8+ZNm2MOHjyIhx9+WH2WZCaiiRMnwojl0b179wyfl9atWztkeYwfPx716tVTM/LJ57p9+/Y4duyYzTE59f9j06ZNqF27tuptXK5cOXz55ZcwYnk0a9Ysw+ejb9++DlkeFtKbmnLPokWLTO7u7qb58+ebDh8+bOrVq5epUKFCpqioKJMjGTNmjKlKlSqmixcvWrbLly9bnu/bt6+pVKlSpvXr15t2795tatiwoalRo0aW51NSUkxVq1Y1NW/e3LRv3z7TqlWrTEWKFDGNGDHCZARyvu+8845p2bJlMjrBtHz5cpvnP/roI5Ofn59pxYoVpgMHDpieeuopU5kyZUy3bt2yHNO6dWtTjRo1TNu3bzdt3rzZVK5cOVPnzp0tz8fExJiKFStmevHFF02HDh0yff/99yYvLy/TnDlzTEYrj27duqn3a/15uXbtms0xjlIerVq1Mi1YsECd4/79+01t27Y1hYSEmG7evJmj/z9Onjxp8vb2Ng0ePNj0999/mz799FOTi4uLafXq1Sajlccjjzyi/lZafz7k39sRy8OMYZzL6tevb+rfv79lPzU11RQcHGwaP368ydHCWP5wZiY6Otrk5uZmWrJkieWxI0eOqD/S27ZtU/vyn8nZ2dkUGRlpOWbWrFkmX19fU2JioslI0odPWlqaqXjx4qZJkybZlImHh4cKECF/LOTndu3aZTnm119/NTk5OZkuXLig9mfOnGny9/e3KY+33nrLVKFCBZM9yyqMn3766Sx/xpHL49KlS+q9/f777zn6/2PYsGHqC7G1jh07qvAzUnmYw3jgwIGmrDhiebCZOhclJSVhz549qknSet5q2d+2bRscjTS7SrNkWFiYal6UZiQhZSBLn1mXgzRhh4SEWMpBbqtVq4ZixYpZjmnVqpWaGP7w4cMwslOnTiEyMtLm/ctctXLJwvr9S1Ns3bp1LcfI8fJ52bFjh+WYpk2bwt3d3aaMpInv+vXrMBppQpTmxQoVKqBfv364evWq5TlHLo+YmBh1GxAQkKP/P+QY69cwH2Pvf2vSl4fZwoULUaRIEVStWhUjRoxQSyeaOWJ5cKGIXHTlyhWkpqbafGCE7B89ehSORIJFrsfIH9aLFy9i7Nix6lreoUOHVBDJH0z545q+HOQ5IbeZlZP5OSMzn39m78/6/UswWXN1dVV/oKyPKVOmTIbXMD/n7+8Po5Drw88++6x6P//++y/efvtttGnTRv2hdHFxcdjykBXdBg0ahMaNG6uQETn1/yOrYySgbt26pfoqGKE8RJcuXRAaGqq+3Eu/gLfeekt9yVq2bJnDlgfDmHKE/CE1q169ugpn+c/0ww8/2N2HnvTXqVMny32p4chnpmzZsqq2/Pjjj8NRSSct+YK6ZcsWvU/Frsujd+/eNp8P6fgonwv54iafE0fEZupcJE0s8i0/fa9I2S9evDgcmXzLf+ihh3DixAn1XqXJPjo6OstykNvMysn8nJGZz/9unwO5vXTpks3z0jNUehTnhzKSSxvy/0U+L45aHgMGDMDKlSuxceNGmyVWc+r/R1bHSG90e/xCnFV5ZEa+3Avrz4ejlQfDOBdJ01OdOnWwfv16m2YZ2Q8PD4cjkyEo8i1WvtFKGbi5udmUgzQ5yTVlcznI7V9//WXzB3jt2rXqP07lypVhZNKUKn8YrN+/NJXJtU/r9y9/jOX6odmGDRvU58X8h0iOkSFDcn3Ruozk0oA9Nslmx/nz59U1Y/m8OFp5SB82CZ7ly5er95C+aT2n/n/IMdavYT7G3v7W3Ks8MrN//351a/35cJTysNC7B1l+GNokvWa//PJL1UO0d+/eamiTdS9ARzBkyBDTpk2bTKdOnTL9+eefasiBDDWQnpLmoRsyfGHDhg1q6EZ4eLja0g9VaNmypRruIMMPAgMDDTO06caNG2qIhWzy32rKlCnq/pkzZyxDm+Tf/aeffjIdPHhQ9STObGhTrVq1TDt27DBt2bLFVL58eZuhPNLrVobydO3aVQ0Lkc+WDN2wt6E89yoPee7NN99UPYXl87Ju3TpT7dq11ftNSEhwuPLo16+fGtYm/z+sh+rEx8dbjsmJ/x/moTxDhw5VvbFnzJhhl0N57lUeJ06cMI0bN06Vg3w+5P9MWFiYqWnTpg5ZHmYM4zwg49vkP5qMN5ahTjJu0tHIkIGgoCD1HkuUKKH25T+VmYTOa6+9poaiyH+QZ555Rv0HtHb69GlTmzZt1FhRCXIJ+OTkZJMRbNy4UYVO+k2G8JiHN40aNUqFh3w5e/zxx03Hjh2zeY2rV6+qsClQoIAaotGjRw8VXNZkjHKTJk3Ua0g5S8gbrTzkj678EZU/njKkJzQ0VI0pTf8F1VHKI7NykE3G2ub0/w8p95o1a6r/hxJg1r/DKOVx9uxZFbwBAQHq31XGl0ugWo8zdqTyMOMSikRERDrjNWMiIiKdMYyJiIh0xjAmIiLSGcOYiIhIZwxjIiIinTGMiYiIdMYwJiIi0hnDmIh016xZM7V6D1F+xUk/iEh3sgCEzM9csGBBvU+FSBcMYyIiIp2xmZqILC5fvqxWmPrwww8tj23dulWtQJZ+BRyzXbt2oUWLFmoJRD8/PzzyyCPYu3ev5XlZo1h+fvPmzZbHJk6ciKJFi1qWuEvfTD1z5kyUL18enp6eakH4559/PpfeMZF9YBgTkUVgYCDmz5+Pd999F7t378aNGzfQtWtXteSdLO6eGTmmW7duaoH47du3qxBt27atetw6aOV1YmJisG/fPowaNQrz5s1TQZue/N7XX38d48aNU0sJrl69Gk2bNs31906kJzZTE1EG/fv3x7p161C3bl21bqzUfj08PO7rZ2XN4UKFCuG7777DE088oR5LSkpS6xA/9NBDOHToEBo3boy5c+dafkYCu2bNmpg2bRqWLVuGHj16qDWOeQ2Z8gvWjIkog48//hgpKSlYsmQJFi5cqIJYFrsvUKCAZTM3ZUtTc69evVSNWJqpZYH3mzdvquPNpJlaXmfp0qVISEjA1KlTs/zd0uQdGhqKsLAwVZuWn4uPj8+T902kF1fdfjMR2a1///0XERERqpZ7+vRpVKtWDcHBwdi/f7/lmICAAHUrTdRXr17F9OnTVYhKcIeHh6vasDW59mzuOS2bj49Ppr9basNyzVmuNa9ZswajR49WzeZSO5caN5EjYjM1EdmQEK1fv75qNq5QoYJqOpamaulwlVV4SocrqcWKc+fOISQkRNV+zZ2yJNzl9T755BMsXrxY/Q5pBnd2ds7QTJ1eXFycCmH5uWeffTZX3zuRXlgzJiIb77zzjupoJcEpzdGrVq1Cz549sXLlykyPl+bpb775Rl1fjo2NxdChQ+Hl5WV5PjU1FS+99BJatWqlrgW3bt1a1bQnT56sjk1Pfs/JkydVpy1/f3/1+6WGLl8MiBwVrxkTkYU0DUvtVMJVrv1KzVXuy7CkWbNmZfozX3zxBa5fv47atWur2rH0hLauRX/wwQc4c+YM5syZo/aDgoJU562RI0fiwIEDGV5PasHSieuxxx5DpUqVMHv2bHz//feoUqVKLr5zIn2xmZqIiEhnrBkTERHpjGFMRESkM4YxERGRzhjGREREOmMYExER6YxhTEREpDOGMRERkc4YxkRERDpjGBMREemMYUxERKQzhjEREZHOGMZERETQ1/8DANMO8jBRO70AAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 500x500 with 1 Axes>"
       ]
@@ -414,8 +472,6 @@
     }
    ],
    "source": [
-    "#print some statistics on the shapes included in the collection and visualize results\n",
-    "print(shape_collection.stats())\n",
     "shape_collection.plot(calibration = True)"
    ]
   },
@@ -424,24 +480,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## write to XML"
+    "## Write to XML"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can now write the selection to a Leica-compatible xml file"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[ 34324. -36853.]\n",
-      "[ 135377. -116583.]\n",
-      "[  36178. -230151.]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "shape_collection.save(\"./test_data/cellculture_example/shapes_2.xml\")"
    ]
@@ -449,7 +502,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "SPARCSpy",
+   "display_name": "pylmd",
    "language": "python",
    "name": "python3"
   },
@@ -463,7 +516,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.11.11"
   },
   "orig_nbformat": 4
  },

--- a/src/lmd/lib.py
+++ b/src/lmd/lib.py
@@ -409,9 +409,9 @@ class Collection:
             assert c.to_geopandas().equals(gdf.drop(columns="well"))
         """
         # Update attributes
-        if self.calibration_points is not None:
+        if calibration_points is not None:
             self.calibration_points = calibration_points
-        if self.global_coordinates is not None:
+        if global_coordinates is not None:
             self.global_coordinates = global_coordinates
 
         self.shapes = [

--- a/src/lmd/lib.py
+++ b/src/lmd/lib.py
@@ -370,6 +370,7 @@ class Collection:
             self, 
             gdf: gpd.GeoDataFrame, 
             geometry_column: str = "geometry",
+            name_column: Optional[str] = None,
             well_column: Optional[str] = None,
             calibration_points: Optional[np.ndarray] = None, 
             global_coordinates: Optional[int] = None,
@@ -392,7 +393,7 @@ class Collection:
             import shapely
 
             gdf = gpd.GeoDataFrame(
-                data={"well": ["A1"]},
+                data={"well": ["A1"], "name": ["test"]},
                 geometry=[shapely.Polygon([[0, 0], [0, 1], [1, 0], [0, 0]])]
             )
 
@@ -416,6 +417,7 @@ class Collection:
         self.shapes = [
             Shape(
                 points=np.array(row[geometry_column].exterior.coords), 
+                name=row[name_column] if name_column is not None else None,
                 well=row[well_column] if well_column is not None else None,
             )
             for _, row in gdf.iterrows()

--- a/src/lmd/lmd_test.py
+++ b/src/lmd/lmd_test.py
@@ -40,13 +40,23 @@ def test_collection_load_geopandas():
         geometry=[shapely.Polygon([[0, 0], [0, 1], [1, 0], [0, 0]])]
     )
 
-    c = Collection()
 
     # Export well metadata
+    c = Collection(calibration_points=np.array([[-1, -1], [1, 1], [0, 1]]))
+    calibration_points_old = c.calibration_points
     c.load_geopandas(gdf, well_column="well", name_column="name")
     assert c.to_geopandas("well", "name").equals(gdf)
+    assert (c.calibration_points == calibration_points_old).all()
+
+    # Overwrite calibration points 
+    c = Collection(calibration_points=np.array([[-1, -1], [1, 1], [0, 1]]))
+    calibration_points_new = np.array([[0, 0], [100, 0], [0, 100]])
+    c.load_geopandas(gdf, well_column="well", name_column="name", calibration_points=calibration_points_new)
+    assert c.to_geopandas("well", "name").equals(gdf)
+    assert (c.calibration_points == calibration_points_new).all()
 
     # Do not export well metadata
+    c = Collection(calibration_points=np.array([[-1, -1], [1, 1], [0, 1]]))
     c.load_geopandas(gdf)
     assert c.to_geopandas().equals(gdf.drop(columns=["well", "name"]))
 

--- a/src/lmd/lmd_test.py
+++ b/src/lmd/lmd_test.py
@@ -36,19 +36,19 @@ def test_plotting():
 
 def test_collection_load_geopandas():
     gdf = gpd.GeoDataFrame(
-        data={"well": ["A1"]},
+        data={"well": ["A1"], "name": "my_shape"},
         geometry=[shapely.Polygon([[0, 0], [0, 1], [1, 0], [0, 0]])]
     )
 
     c = Collection()
-    
+
     # Export well metadata
-    c.load_geopandas(gdf, well_column="well")
-    assert c.to_geopandas("well").equals(gdf)
+    c.load_geopandas(gdf, well_column="well", name_column="name")
+    assert c.to_geopandas("well", "name").equals(gdf)
 
     # Do not export well metadata
     c.load_geopandas(gdf)
-    assert c.to_geopandas().equals(gdf.drop(columns="well"))
+    assert c.to_geopandas().equals(gdf.drop(columns=["well", "name"]))
 
 def test_collection_save():
     calibration = np.array([[0, 0], [0, 100], [50, 50]])

--- a/src/lmd/lmd_test.py
+++ b/src/lmd/lmd_test.py
@@ -5,6 +5,8 @@ from PIL import Image
 from lmd.lib import SegmentationLoader
 import pathlib
 import os
+import geopandas as gpd 
+import shapely 
 
 def test_collection():
     calibration = np.array([[0, 0], [0, 100], [50, 50]])
@@ -31,7 +33,23 @@ def test_plotting():
     my_first_collection.new_shape(triangle_coordinates)
 
     my_first_collection.plot(calibration = True)
+
+def test_collection_load_geopandas():
+    gdf = gpd.GeoDataFrame(
+        data={"well": ["A1"]},
+        geometry=[shapely.Polygon([[0, 0], [0, 1], [1, 0], [0, 0]])]
+    )
+
+    c = Collection()
     
+    # Export well metadata
+    c.load_geopandas(gdf, well_column="well")
+    assert c.to_geopandas("well").equals(gdf)
+
+    # Do not export well metadata
+    c.load_geopandas(gdf)
+    assert c.to_geopandas().equals(gdf.drop(columns="well"))
+
 def test_collection_save():
     calibration = np.array([[0, 0], [0, 100], [50, 50]])
     my_first_collection = Collection(calibration_points = calibration)


### PR DESCRIPTION
Load collections from geopandas. Increases the interoperability of pylmd with geopandas (and spatialdata), as it is now possible to easily switch between collections class and geopandas. 

## Example: 

```python 
from lmd.lib import Collection
import geopandas as gpd
import shapely

gdf = gpd.GeoDataFrame(
    data={"well": ["A1"]},
    geometry=[shapely.Polygon([[0, 0], [0, 1], [1, 0], [0, 0]])]
)

# Create collection
c = Collection()

# Export well metadata
c.load_geopandas(gdf, well_column="well")
assert c.to_geopandas("well").equals(gdf)

# Do not export well metadata
c.load_geopandas(gdf)
assert c.to_geopandas().equals(gdf.drop(columns="well"))
```