### PR TITLE
Custom shapes attributes

### DIFF
--- a/src/lmd/lib.py
+++ b/src/lmd/lib.py
@@ -275,9 +275,9 @@ class Collection:
             name: Name of the shape.
 
             custom_attributes: Custom shape metadata that will can be added as additional xml-element to the shape
+                Only string values are correctly parsed
 
         """
-
         to_add = Shape(
             points,
             well=well,
@@ -555,7 +555,7 @@ class Shape:
         well: Optional[str] = None,
         name: Optional[str] = None,
         orientation_transform=None,
-        **custom_attributes: dict[str, None | str | int | float]
+        **custom_attributes: dict[str, str]
     ):
         """Class for creating a single shape.
 
@@ -567,10 +567,8 @@ class Shape:
             name: Name of the shape.
 
             custom_attributes: Custom shape metadata that will can be added as additional xml-element to the shape
+                Values be implicitly converted to strings.
         """
-        if not all(isinstance(v, None | str | int | float) for v in custom_attributes.values()):
-            raise ValueError("Custom attributes only support None, str, int, float type arguments")
-
         # Orientation transform of shapes
         self.orientation_transform: Optional[np.ndarray] = orientation_transform
 

--- a/src/lmd/lib.py
+++ b/src/lmd/lib.py
@@ -542,7 +542,7 @@ class Shape:
         well: Optional[str] = None,
         name: Optional[str] = None,
         orientation_transform=None,
-        **custom_attributes: dict[str, str | int | float]
+        **custom_attributes: dict[str, None | str | int | float]
     ):
         """Class for creating a single shape.
 
@@ -615,7 +615,7 @@ class Shape:
 
         self.points = np.array(points)
 
-    def to_xml(self, id: int, orientation_transform: np.ndarray, scale: int):
+    def to_xml(self, id: int, orientation_transform: np.ndarray, scale: int, *, write_custom_attributes: bool = True):
         """Generate XML shape node needed internally for export.
 
         Args:
@@ -624,6 +624,8 @@ class Shape:
             orientation_transform (np.array): Pass orientation_transform which is used if no local orientation transform is set.
 
             scale (int): Scalling factor used to enable higher decimal precision.
+
+            write_custom_attributes: Write custom attributes to xml file
 
         Note:
             If the Shape has a custom orientation_transform defined, the custom orientation_transform is applied at this point. If not, the oritenation_transform passed by the parent Collection is used. This highlights an important difference between the Shape and Collection class. The Collection will always has an orientation transform defined and will use `np.eye(2)` by default. The Shape object can have a orientation_transform but can also be set to `None` to use the Collection value.
@@ -645,6 +647,11 @@ class Shape:
         if self.well is not None:
             cap_id = ET.SubElement(shape, "CapID")
             cap_id.text = self.well
+
+        if write_custom_attributes:
+            for attribute_name, attribute_value in self.custom_attributes.items():
+                custom_attribute = ET.SubElement(shape, attribute_name)
+                custom_attribute.text = attribute_value
 
         # write points
         for i, point in enumerate(transformed_points):

--- a/src/lmd/lib.py
+++ b/src/lmd/lib.py
@@ -263,7 +263,7 @@ class Collection:
             TypeError("Provided shape is not of type Shape")
 
     def new_shape(
-        self, points: np.ndarray, well: Optional[str] = None, name: Optional[str] = None
+        self, points: np.ndarray, well: Optional[str] = None, name: Optional[str] = None, **custom_attributes
     ):
         """Directly create a new Shape in the current collection.
 
@@ -273,6 +273,9 @@ class Collection:
             well: Well in which to sort the shape after cutting. For example A1, A2 or B3.
 
             name: Name of the shape.
+
+            custom_attributes: Custom shape metadata that will can be added as additional xml-element to the shape
+
         """
 
         to_add = Shape(
@@ -280,6 +283,7 @@ class Collection:
             well=well,
             name=name,
             orientation_transform=self.orientation_transform,
+            **custom_attributes
         )
         self.add_shape(to_add)
 
@@ -555,8 +559,6 @@ class Shape:
 
             custom_attributes: Custom shape metadata that will can be added as additional xml-element to the shape
         """
-        custom_attributes = custom_attributes if custom_attributes is not None else {}
-
         if not all(isinstance(v, None | str | int | float) for v in custom_attributes.values()):
             raise ValueError("Custom attributes only support None, str, int, float type arguments")
 

--- a/src/lmd/lib.py
+++ b/src/lmd/lib.py
@@ -542,6 +542,7 @@ class Shape:
         well: Optional[str] = None,
         name: Optional[str] = None,
         orientation_transform=None,
+        **custom_attributes: dict[str, str | int | float]
     ):
         """Class for creating a single shape.
 
@@ -551,7 +552,13 @@ class Shape:
             well: Well in which to sort the shape after cutting. For example A1, A2 or B3.
 
             name: Name of the shape.
+
+            custom_attributes: Custom shape metadata that will can be added as additional xml-element to the shape
         """
+        custom_attributes = custom_attributes if custom_attributes is not None else {}
+
+        if not all(isinstance(v, None | str | int | float) for v in custom_attributes.values()):
+            raise ValueError("Custom attributes only support None, str, int, float type arguments")
 
         # Orientation transform of shapes
         self.orientation_transform: Optional[np.ndarray] = orientation_transform
@@ -568,6 +575,8 @@ class Shape:
 
         self.name: Optional[str] = name
         self.well: Optional[str] = well
+
+        self.custom_attributes = custom_attributes
 
     def from_xml(self, root):
         """Load a shape from an XML shape node. Used internally for reading LMD generated XML files.

--- a/src/lmd/lib.py
+++ b/src/lmd/lib.py
@@ -274,8 +274,8 @@ class Collection:
 
             name: Name of the shape.
 
-            custom_attributes: Custom shape metadata that will can be added as additional xml-element to the shape
-                Only string values are correctly parsed
+            custom_attributes: Custom shape metadata that can be added as additional xml-element to the shape.
+                All values are converted to strings.
 
         """
         to_add = Shape(
@@ -323,7 +323,14 @@ class Collection:
         .. code-block:: python
             # Generate collection
             collection = pylmd.Collection()
-            shape = pylmd.Shape(np.array([[ 0,  0], [ 0, -1], [ 1,  0], [ 0,  0]]), well="A1", name="Shape_1", orientation_transform=None)
+            shape = pylmd.Shape(
+                    np.array([[ 0,  0], [ 0, -1], [ 1,  0], [ 0,  0]]), 
+                    well="A1", 
+                    name="Shape_1", 
+                    metadata1="A",
+                    metadata2="B",
+                    orientation_transform=None
+                )
             collection.add_shape(shape)
 
             # Get geopandas object
@@ -331,9 +338,9 @@ class Collection:
             >       geometry
                 0   POLYGON ((0 0, 0 -1, 1 0, 0 0))
 
-            collection.to_geopandas("well", "name")
-            >   well     name                         geometry
-                0   A1  Shape_1  POLYGON ((0 0, 0 -1, 1 0, 0 0))
+            collection.to_geopandas("well", "name", "metadata1", "metadata2")
+            >       well    name            metadata1 metadata2  geometry
+                0   A1      Shape_1         A         B          POLYGON ((0 0, 0 -1, 1 0, 0 0))
         """
         metadata = (
             pd.DataFrame(
@@ -566,7 +573,7 @@ class Shape:
 
             name: Name of the shape.
 
-            custom_attributes: Custom shape metadata that will can be added as additional xml-element to the shape
+            custom_attributes: Custom shape metadata that will be added as additional xml-element to the shape
                 Values be implicitly converted to strings.
         """
         # Orientation transform of shapes

--- a/src/lmd/lib.py
+++ b/src/lmd/lib.py
@@ -397,6 +397,7 @@ class Collection:
             well_column: Optional[str] = None,
             calibration_points: Optional[np.ndarray] = None, 
             global_coordinates: Optional[int] = None,
+            *custom_attribute_columns: str
         ) -> None:
         """Create collection from a geopandas dataframe
         
@@ -406,6 +407,7 @@ class Collection:
             well_column (str, optional): Column storing of well id as additional metadata
             calibration_points (np.ndarray, optional): Calibration points of collection 
             global_coordinates (int, optional): Number of global coordinates
+            custom_attribute_columns Custom shape metadata that will be added as additional xml-element to the shape
 
         Example:
 
@@ -437,11 +439,15 @@ class Collection:
         if global_coordinates is not None:
             self.global_coordinates = global_coordinates
 
+        if custom_attribute_columns is None:
+            custom_attribute_columns = []
+
         self.shapes = [
             Shape(
                 points=np.array(row[geometry_column].exterior.coords), 
                 name=row[name_column] if name_column is not None else None,
                 well=row[well_column] if well_column is not None else None,
+                **{att: row[att] for att in custom_attribute_columns}
             )
             for _, row in gdf.iterrows()
         ]

--- a/src/lmd/lib.py
+++ b/src/lmd/lib.py
@@ -619,7 +619,7 @@ class Shape:
                 self.well = str(child.text)
             else: 
                 if child.tag in self.custom_attributes:
-                    warnings.warn("Shape attribute {child.tag} already found in shape, overwrite", stacklevel=1)
+                    warnings.warn(f"Shape attribute {child.tag} already found in shape, overwrite", stacklevel=1)
                 self.custom_attributes[child.tag] = child.text
 
         self.points = np.array(points)
@@ -691,7 +691,7 @@ class Shape:
         elif name in self.custom_attributes:
             return self.custom_attributes.get(name)
         else:
-            warnings.warn(f"Attribute '{name}' not found in shape attributes. Returning None.")
+            warnings.warn(f"Attribute {name} not found in shape attributes. Returning None.")
             return None
 
 

--- a/src/lmd/lib.py
+++ b/src/lmd/lib.py
@@ -397,7 +397,7 @@ class Collection:
             well_column: Optional[str] = None,
             calibration_points: Optional[np.ndarray] = None, 
             global_coordinates: Optional[int] = None,
-            *custom_attribute_columns: str
+            custom_attribute_columns: str | list[str] | None = None,
         ) -> None:
         """Create collection from a geopandas dataframe
         
@@ -407,7 +407,8 @@ class Collection:
             well_column (str, optional): Column storing of well id as additional metadata
             calibration_points (np.ndarray, optional): Calibration points of collection 
             global_coordinates (int, optional): Number of global coordinates
-            custom_attribute_columns Custom shape metadata that will be added as additional xml-element to the shape
+            custom_attribute_columns Custom shape metadata that will be added as additional xml-element to the shape. 
+                Can be column name, list of column names or None
 
         Example:
 
@@ -441,6 +442,8 @@ class Collection:
 
         if custom_attribute_columns is None:
             custom_attribute_columns = []
+        if isinstance(custom_attribute_columns, str):
+            custom_attribute_columns = [custom_attribute_columns]
 
         self.shapes = [
             Shape(

--- a/src/lmd/lib.py
+++ b/src/lmd/lib.py
@@ -338,7 +338,7 @@ class Collection:
         metadata = (
             pd.DataFrame(
                 [
-                    [shape.get_shape_annotation(att) | shape.custom_attributes.get(att) for att in attrs]
+                    [shape.get_shape_annotation(att) for att in attrs]
                     for shape in self.shapes
                 ],
                 columns=attrs,

--- a/src/lmd/lib.py
+++ b/src/lmd/lib.py
@@ -608,6 +608,10 @@ class Shape:
                 points[point_id, 1] = int(child.text)  
             elif child.tag == "CapID":
                 self.well = str(child.text)
+            else: 
+                if child.tag in self.custom_attributes:
+                    warnings.warn("Shape attribute {child.tag} already found in shape, overwrite", stacklevel=1)
+                self.custom_attributes[child.tag] = child.text
 
         self.points = np.array(points)
 

--- a/src/lmd/lib.py
+++ b/src/lmd/lib.py
@@ -660,7 +660,8 @@ class Shape:
         if write_custom_attributes:
             for attribute_name, attribute_value in self.custom_attributes.items():
                 custom_attribute = ET.SubElement(shape, attribute_name)
-                custom_attribute.text = attribute_value
+                # xml only accepts string values
+                custom_attribute.text = str(attribute_value)
 
         # write points
         for i, point in enumerate(transformed_points):

--- a/src/lmd/lmd_test.py
+++ b/src/lmd/lmd_test.py
@@ -24,6 +24,9 @@ def test_shape_from_xml():
         <PointCount>3</PointCount>
         <CapID>A1</CapID>
         <TEST>this is a test</TEST>
+        <test2>1</test2>
+        <test3>3.1415</test3>
+
         <X_1>0</X_1>
         <Y_1>-0</Y_1>
         <X_2>0</X_2>
@@ -41,6 +44,10 @@ def test_shape_from_xml():
     shape.from_xml(shape_xml)
     assert (shape.points == np.array([[ 0,  0], [ 0, -1], [ 1,  0]])).all()
     assert shape.well == "A1"
+    assert shape.custom_attributes["TEST"] == "this is a test"
+    assert shape.custom_attributes["test2"] == "1"
+    assert shape.custom_attributes["test3"] == "3.1415"
+
 
 def test_plotting():
     calibration = np.array([[0, 0], [0, 100], [50, 50]])


### PR DESCRIPTION
Addresses issue #37 and enables users to define custom attributes for shapes.

> This PR is marked as draft until generated test data has been tested on a Leica instrument ([Example data]( https://datashare.biochem.mpg.de/s/udqna1ESrySM58X))

## Added functionalities 
- Read custom attributes via standard API (`Collection.load`)
- Write custom attributes to XML tags. 
- Interact with `geopandas.GeoDataFrame`s

## Limitations
As `xml` is parsed as text per default, all attributes will become strings. This is enforced and documented in the respective docstrings

## Implementation
Custom attributes are stored in the `custom_attributes` class attribute (`dict[str, str]`) in the Shapes class. This implementation assures that the Shapes API remains "stable" (i.e. for any amount of added metadata, the Shapes class will have the same attributes), but also leads to a distinction between established fields (well, CapID) and remaining fields. 