### PR TITLE
Fix data download

### DIFF
--- a/src/lmd/_utils.py
+++ b/src/lmd/_utils.py
@@ -14,26 +14,10 @@ from tqdm import tqdm
 
 
 def _get_data_dir() -> Path:
-    """Get path to data that was packaged with scPortrait.
-
-    Returns:
-        Path to data directory
-    """
-
-    def find_root_by_folder(marker_folder: str, current_path: Path) -> Path | None:
-        for parent in current_path.parents:
-            if (parent / marker_folder).is_dir():
-                return parent
-        return None
-
-    src_code_dir = find_root_by_folder("lmd", Path(__file__))
-
-    if src_code_dir is None:
-        raise FileNotFoundError("Could not find pyLMD source directory")
-
-    data_dir = src_code_dir / "pylmd_data"
-
-    return data_dir.absolute()
+    """Get path to pyLMD data/cache directory."""
+    data_dir = Path.home() / ".pylmd"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return data_dir
 
 
 def _download(

--- a/src/lmd/_utils.py
+++ b/src/lmd/_utils.py
@@ -120,9 +120,11 @@ def _download_glyphs() -> Path:
     data_dir = Path(_get_data_dir())
     save_path = data_dir / "glyphs"
 
+    DOWNLOAD_URL = "https://datashare.biochem.mpg.de/s/2YfyHFEyXNsaf5M/download"
+
     if not save_path.exists():
         _download(
-            url="https://zenodo.org/records/14623414/files/glyphs.zip?download=1",
+            url=DOWNLOAD_URL,
             output_path=str(save_path),
             archive_format="zip",
         )
@@ -130,7 +132,7 @@ def _download_glyphs() -> Path:
         # check that directory is not empty
         if not any(save_path.iterdir()):
             _download(
-                url="https://zenodo.org/records/14623414/files/glyphs.zip?download=1",
+                url=DOWNLOAD_URL,
                 output_path=str(save_path),
                 archive_format="zip",
             )
@@ -147,11 +149,12 @@ def _download_segmentation_example_file() -> Path:
 
     data_dir = Path(_get_data_dir())
     save_path = data_dir / "segmentation_cytosol_example"
+    DOWNLOAD_URL = "https://datashare.biochem.mpg.de/s/QZtxFNDy8gSqTqf/download"
 
     output_file_name = "segmentation_mask.tif"
     if not save_path.exists():
         _download(
-            url="https://zenodo.org/records/15681419/files/segmentation_cytosol.tiff?download=1",
+            url=DOWNLOAD_URL,
             output_path=str(save_path),
             output_file_name=output_file_name,
             archive_format=None,

--- a/tests/integration/test_downloads.py
+++ b/tests/integration/test_downloads.py
@@ -8,16 +8,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from lmd._utils import _download_glyphs, _download_segmentation_example_file
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
 
-# TODO: Enable download of glyphs
-@pytest.mark.skip(reason="Zenodo download is currently unauthorized (HTTP: 403)")
+
 class TestDownloadGlyphsIntegration:
     """Integration tests for _download_glyphs with real downloads."""
 
@@ -35,19 +33,17 @@ class TestDownloadGlyphsIntegration:
         assert result.exists()
         assert result.is_dir()
 
-        # Check that glyph XML files were extracted
-        xml_files = list(result.rglob("*.xml"))
-        assert len(xml_files) > 0, "Expected glyph XML files to be extracted"
+        # Check that glyph SVG files were extracted
+        svg_files = list(result.rglob("*.svg"))
+        assert len(svg_files) > 0, f"Expected glyph SVG files to be extracted, found {list(result.glob('*'))}"
 
         # Verify at least some expected glyphs exist (0-9, a-i, A-I)
-        glyph_names = {f.stem for f in xml_files}
+        glyph_names = {f.stem for f in svg_files}
         expected_glyphs = {"0", "1", "2", "a", "b", "A", "B"}
         found_glyphs = expected_glyphs & glyph_names
         assert len(found_glyphs) > 0, f"Expected some standard glyphs, found: {glyph_names}"
 
 
-# TODO: Enable download of glyphs
-@pytest.mark.skip(reason="Zenodo download is currently unauthorized (HTTP: 403)")
 class TestDownloadSegmentationIntegration:
     """Integration tests for _download_segmentation_example_file with real downloads."""
 

--- a/tests/unit/test_lmd/test__utils.py
+++ b/tests/unit/test_lmd/test__utils.py
@@ -18,12 +18,12 @@ class TestGetDataDir:
     """Tests for _get_data_dir function."""
 
     def test_returns_path(self) -> None:
-        """Test that _get_data_dir returns an absolute Path object that ends with pylmd_data."""
+        """Test that _get_data_dir returns an absolute Path object that ends with .pylmd."""
         result = _get_data_dir()
 
         assert isinstance(result, Path)
         assert result.is_absolute()
-        assert result.name == "pylmd_data"
+        assert result.name == ".pylmd"
 
 
 class TestDownload:
@@ -216,7 +216,7 @@ class TestDownloadGlyphs:
     @pytest.fixture
     def mock_data_dir(self, tmp_path: Path) -> Path:
         """Fixture providing a mock data directory."""
-        data_dir = tmp_path / "pylmd_data"
+        data_dir = tmp_path / ".pylmd"
         data_dir.mkdir(parents=True, exist_ok=True)
         return data_dir
 
@@ -294,7 +294,7 @@ class TestDownloadSegmentationExampleFile:
     @pytest.fixture
     def mock_data_dir(self, tmp_path: Path) -> Path:
         """Fixture providing a mock data directory."""
-        data_dir = tmp_path / "pylmd_data"
+        data_dir = tmp_path / ".pylmd"
         data_dir.mkdir(parents=True, exist_ok=True)
         return data_dir
 

--- a/tests/unit/test_lmd/test__utils.py
+++ b/tests/unit/test_lmd/test__utils.py
@@ -256,7 +256,6 @@ class TestDownloadGlyphs:
 
         mock_download.assert_called_once()
         call_kwargs = mock_download.call_args[1]
-        assert "glyphs.zip" in call_kwargs["url"]
         assert call_kwargs["archive_format"] == "zip"
 
     def test_downloads_when_directory_is_empty(self, mock_data_dir: Path) -> None:
@@ -332,7 +331,6 @@ class TestDownloadSegmentationExampleFile:
 
         mock_download.assert_called_once()
         call_kwargs = mock_download.call_args[1]
-        assert "segmentation_cytosol.tiff" in call_kwargs["url"]
         assert call_kwargs["output_file_name"] == "segmentation_mask.tif"
         assert call_kwargs["archive_format"] is None
 

--- a/tests/unit/test_lmd/test_tools.py
+++ b/tests/unit/test_lmd/test_tools.py
@@ -27,8 +27,6 @@ def test__get_rotation_matrix(angle_rad: float, expected_matrix: np.ndarray) -> 
     assert np.allclose(result, expected_matrix, atol=ATOL)
 
 
-# TODO: Resolve authentification issues
-@pytest.mark.skip(reason="Skip due to issues with the authentification of glyph download in tests (HTTP: 403)")
 class TestGlyphPath:
     @pytest.mark.parametrize(("glyph_string",), argvalues=list("0123456789abcdefghiABCDEFGHI"))
     def test_glyph_path(self, glyph_string: str) -> None:
@@ -44,8 +42,6 @@ class TestGlyphPath:
             _ = tools.glyph_path(glyph=glyph_string)
 
 
-# TODO: Resolve authentification issues
-@pytest.mark.skip(reason="Skip due to issues with the authentification of glyph download in tests (HTTP: 403)")
 class TestGlyph:
     @pytest.mark.parametrize(("glyph_string",), argvalues=list("0123456789abcdefghiABCDEFGHI"))
     def test_glyph(self, glyph_string: str) -> None:
@@ -106,8 +102,6 @@ class TestGlyph:
         assert np.allclose(scaled_size, expected_size, rtol=0.01)
 
 
-# TODO: Resolve authentification issues
-@pytest.mark.skip(reason="Skip due to issues with the authentification of glyph download in tests (HTTP: 403)")
 class TestText:
     @pytest.mark.parametrize(("text_string",), argvalues=[("a",), ("abc",)])
     def test_text(self, text_string: str) -> None:


### PR DESCRIPTION
Moves download location of glyphs and example segmentation mask from Zenodo (which leads to authorization issues/HTTP 403 responses) to the more permissive MPIB datashare. 

Update unit+integration tests so that they are no longer skipped. 