### PR TITLE
[Fix] glyph download

### DIFF
--- a/src/lmd/_utils.py
+++ b/src/lmd/_utils.py
@@ -87,6 +87,7 @@ def _download(
             else:
                 print(f"{warning} Overwriting...")
 
+        # Zenodo declines downloads from requests without identifying headers (HTTP 403).
         headers = {"User-Agent": "pyLMD/1.0"}
         response = requests.get(url, stream=True, headers=headers)
         response.raise_for_status()

--- a/src/lmd/_utils.py
+++ b/src/lmd/_utils.py
@@ -87,7 +87,9 @@ def _download(
             else:
                 print(f"{warning} Overwriting...")
 
-        response = requests.get(url, stream=True)
+        headers = {"User-Agent": "pyLMD/1.0"}
+        response = requests.get(url, stream=True, headers=headers)
+        response.raise_for_status()
         total = int(response.headers.get("content-length", 0))
 
         temp_file_name = f"{download_to_path}.part"

--- a/tests/integration/test_downloads.py
+++ b/tests/integration/test_downloads.py
@@ -2,6 +2,13 @@
 
 These tests actually download files from Zenodo and validate the content.
 They require network access and may be slow.
+
+NOTE: While it is unusual to call third-party services in tests (typically you
+would mock requests), these integration tests serve as end-to-end validation
+that the download URLs and extraction logic work correctly with the real
+upstream data. They have proven valuable in catching real issues (e.g., server
+header requirements, URL changes). The unit tests in test_utils.py mock the
+network layer for fast, isolated testing.
 """
 
 from __future__ import annotations
@@ -26,14 +33,12 @@ class TestDownloadGlyphsIntegration:
         data_dir.mkdir(parents=True, exist_ok=True)
         monkeypatch.setattr("lmd._utils._get_data_dir", lambda: data_dir)
 
-        # Act
         result = _download_glyphs()
 
-        # Assert
         assert result.exists()
         assert result.is_dir()
 
-        # Check that glyph XML files were extracted
+        # Check that glyph SVG files were extracted
         svg_files = list(result.rglob("*.svg"))
         assert len(svg_files) > 0, "Expected glyph SVG files to be extracted"
 

--- a/tests/integration/test_downloads.py
+++ b/tests/integration/test_downloads.py
@@ -8,16 +8,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from lmd._utils import _download_glyphs, _download_segmentation_example_file
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
 
-# TODO: Enable download of glyphs
-@pytest.mark.skip(reason="Zenodo download is currently unauthorized (HTTP: 403)")
+
 class TestDownloadGlyphsIntegration:
     """Integration tests for _download_glyphs with real downloads."""
 
@@ -36,18 +34,16 @@ class TestDownloadGlyphsIntegration:
         assert result.is_dir()
 
         # Check that glyph XML files were extracted
-        xml_files = list(result.rglob("*.xml"))
-        assert len(xml_files) > 0, "Expected glyph XML files to be extracted"
+        svg_files = list(result.rglob("*.svg"))
+        assert len(svg_files) > 0, "Expected glyph SVG files to be extracted"
 
         # Verify at least some expected glyphs exist (0-9, a-i, A-I)
-        glyph_names = {f.stem for f in xml_files}
+        glyph_names = {f.stem for f in svg_files}
         expected_glyphs = {"0", "1", "2", "a", "b", "A", "B"}
         found_glyphs = expected_glyphs & glyph_names
         assert len(found_glyphs) > 0, f"Expected some standard glyphs, found: {glyph_names}"
 
 
-# TODO: Enable download of glyphs
-@pytest.mark.skip(reason="Zenodo download is currently unauthorized (HTTP: 403)")
 class TestDownloadSegmentationIntegration:
     """Integration tests for _download_segmentation_example_file with real downloads."""
 

--- a/tests/unit/test_lmd/test_tools.py
+++ b/tests/unit/test_lmd/test_tools.py
@@ -103,7 +103,7 @@ class TestGlyph:
 
 
 class TestText:
-    @pytest.mark.parametrize(("text_string",), argvalues=[("a",), ("abc",)])
+    @pytest.mark.parametrize(("text_string",), argvalues=[("A",), ("ABC",)])
     def test_text(self, text_string: str) -> None:
         """Test that function returns a collection"""
         result = tools.text(text=text_string)

--- a/tests/unit/test_lmd/test_tools.py
+++ b/tests/unit/test_lmd/test_tools.py
@@ -27,8 +27,6 @@ def test__get_rotation_matrix(angle_rad: float, expected_matrix: np.ndarray) -> 
     assert np.allclose(result, expected_matrix, atol=ATOL)
 
 
-# TODO: Resolve authentification issues
-@pytest.mark.skip(reason="Skip due to issues with the authentification of glyph download in tests (HTTP: 403)")
 class TestGlyphPath:
     @pytest.mark.parametrize(("glyph_string",), argvalues=list("0123456789abcdefghiABCDEFGHI"))
     def test_glyph_path(self, glyph_string: str) -> None:
@@ -44,8 +42,6 @@ class TestGlyphPath:
             _ = tools.glyph_path(glyph=glyph_string)
 
 
-# TODO: Resolve authentification issues
-@pytest.mark.skip(reason="Skip due to issues with the authentification of glyph download in tests (HTTP: 403)")
 class TestGlyph:
     @pytest.mark.parametrize(("glyph_string",), argvalues=list("0123456789abcdefghiABCDEFGHI"))
     def test_glyph(self, glyph_string: str) -> None:
@@ -106,8 +102,6 @@ class TestGlyph:
         assert np.allclose(scaled_size, expected_size, rtol=0.01)
 
 
-# TODO: Resolve authentification issues
-@pytest.mark.skip(reason="Skip due to issues with the authentification of glyph download in tests (HTTP: 403)")
 class TestText:
     @pytest.mark.parametrize(("text_string",), argvalues=[("a",), ("abc",)])
     def test_text(self, text_string: str) -> None:

--- a/tests/unit/test_lmd/test_tools.py
+++ b/tests/unit/test_lmd/test_tools.py
@@ -28,7 +28,7 @@ def test__get_rotation_matrix(angle_rad: float, expected_matrix: np.ndarray) -> 
 
 
 class TestGlyphPath:
-    @pytest.mark.parametrize(("glyph_string",), argvalues=list("0123456789abcdefghiABCDEFGHI"))
+    @pytest.mark.parametrize(("glyph_string",), argvalues=list("0123456789ABCDEFGHI"))
     def test_glyph_path(self, glyph_string: str) -> None:
         """Test that implemented glyphs exist (only glyphs A-I implemented)"""
         result = tools.glyph_path(glyph=glyph_string)
@@ -43,7 +43,7 @@ class TestGlyphPath:
 
 
 class TestGlyph:
-    @pytest.mark.parametrize(("glyph_string",), argvalues=list("0123456789abcdefghiABCDEFGHI"))
+    @pytest.mark.parametrize(("glyph_string",), argvalues=list("0123456789ABCDEFGHI"))
     def test_glyph(self, glyph_string: str) -> None:
         """Test that collection is created from a glyph"""
 


### PR DESCRIPTION
Fix glyph download by adding User-Agent header to requests. Zenodo declines downloads from requests without identifying headers (HTTP 403).

Added `raise_for_status` to raise HTTP issues and facilitate debugging.