### PR TITLE
pyLMD v2.0.0 - Expose TSP path optimization method to users 

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install package
       run: |
         pip install uv
-        uv pip install --system ".[tests, dev]"
+        uv pip install --system ".[tests, dev, umap]"
     - name: Run pre-commit checks
       run: |
         pre-commit install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dependencies = {file = ["requirements.txt"]}
 
 [tool.setuptools.dynamic.optional-dependencies]
-umap = {"umap-learn"}
+umap = {file = ["requirements_umap.txt"]}
 dev_only = {file = ["requirements_dev.txt"]}
 doc = {file = ["requirements_doc.txt"]}
 test = {file = ["requirements_test.txt"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 dependencies = {file = ["requirements.txt"]}
 
 [tool.setuptools.dynamic.optional-dependencies]
+umap = {"umap-learn"}
 dev_only = {file = ["requirements_dev.txt"]}
 doc = {file = ["requirements_doc.txt"]}
 test = {file = ["requirements_test.txt"]}

--- a/requirements_umap.txt
+++ b/requirements_umap.txt
@@ -1,0 +1,2 @@
+pre-commit
+pytest

--- a/requirements_umap.txt
+++ b/requirements_umap.txt
@@ -1,2 +1,1 @@
-pre-commit
-pytest
+umap-learn

--- a/src/lmd/lib/_geom.py
+++ b/src/lmd/lib/_geom.py
@@ -361,7 +361,7 @@ class Collection:
         if isinstance(shape, Shape):
             self.shapes.append(shape)
         else:
-            TypeError("Provided shape is not of type Shape")
+            raise TypeError("Provided shape is not of type Shape")
 
     def new_shape(
         self,

--- a/src/lmd/lib/_geom.py
+++ b/src/lmd/lib/_geom.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import re
-
-# import warnings
 import warnings
 from typing import Any
 

--- a/src/lmd/lib/_segmentation.py
+++ b/src/lmd/lib/_segmentation.py
@@ -33,11 +33,17 @@ class SegmentationLoader:
 
         Args:
             config (dict): Dict containing configuration parameters. See Note for further explanation.
+
             processes (int): Number of processes used for parallel processing of cell sets. Total processes can be calculated as `processes * threads`.
+
             threads (int): Number of threads used for parallel processing of shapes within a cell set. Total processes can be calculated as `processes * threads`.
+
             cell_sets (list(dict)): List of dictionaries containing the sets of cells which should be sorted into a single well.
+
             calibration_points (np.array): Array of size '(3,2)' containing the calibration marker coordinates in the '(row, column)' format.
+
             coords_lookup (None, dict): precalculated lookup table for coordinates of individual cell ids. If not provided will be calculated.
+
             classes (np.array): Array of classes found in the provided segmentation mask. If not provided will be calculated based on the assumption that cell_ids are assigned in ascending order.
 
         Example:

--- a/src/lmd/lib/_segmentation.py
+++ b/src/lmd/lib/_segmentation.py
@@ -550,6 +550,7 @@ class SegmentationLoader:
             else:
                 path = os.path.join(Path(self.directory).parents[0], cell_set["classes"])
 
+            # TODO: Close file again https://github.com/MannLabs/py-lmd/pull/61#discussion_r2692370486
             if os.path.isfile(path):
                 try:
                     cr = csv.reader(open(path))

--- a/src/lmd/lib/_segmentation.py
+++ b/src/lmd/lib/_segmentation.py
@@ -375,6 +375,7 @@ class SegmentationLoader:
             optimized_length = calc_len(center)
             self.log(f"Optimized path length: {optimized_length:,.2f} units")
 
+            # TODO: Remove unused variable optimization_factor
             optimization_factor = unoptimized_length / optimized_length
             self.log(f"Optimization factor: {optimization_factor:,.1f}x")
         else:

--- a/src/lmd/lib/_segmentation.py
+++ b/src/lmd/lib/_segmentation.py
@@ -581,7 +581,7 @@ class SegmentationLoader:
             raise NotImplementedError("registration of parameters is not yet supported for nested parameters")
 
         else:
-            raise TypeError("Key musst be of string or a list of strings")
+            raise TypeError("Key must be of string or a list of strings")
 
         if key not in config_handle:
             self.log(f"No configuration for {key} found, parameter will be set to {value}")

--- a/src/lmd/lib/_segmentation.py
+++ b/src/lmd/lib/_segmentation.py
@@ -35,13 +35,9 @@ class SegmentationLoader:
             config (dict): Dict containing configuration parameters. See Note for further explanation.
             processes (int): Number of processes used for parallel processing of cell sets. Total processes can be calculated as `processes * threads`.
             threads (int): Number of threads used for parallel processing of shapes within a cell set. Total processes can be calculated as `processes * threads`.
-
             cell_sets (list(dict)): List of dictionaries containing the sets of cells which should be sorted into a single well.
-
-            calibration_marker (np.array): Array of size '(3,2)' containing the calibration marker coordinates in the '(row, column)' format.
-
+            calibration_points (np.array): Array of size '(3,2)' containing the calibration marker coordinates in the '(row, column)' format.
             coords_lookup (None, dict): precalculated lookup table for coordinates of individual cell ids. If not provided will be calculated.
-
             classes (np.array): Array of classes found in the provided segmentation mask. If not provided will be calculated based on the assumption that cell_ids are assigned in ascending order.
 
         Example:
@@ -51,13 +47,6 @@ class SegmentationLoader:
                 import numpy as np
                 from PIL import Image
                 from lmd.lib import SegmentationLoader
-
-    Args:
-        config (dict): Dict containing configuration parameters. See Note for further explanation.
-
-        cell_sets (list(dict)): List of dictionaries containing the sets of cells which should be sorted into a single well.
-
-        calibration_marker (np.array): Array of size '(3,2)' containing the calibration marker coordinates in the '(row, column)' format.
 
     Example:
 

--- a/src/lmd/lib/_segmentation.py
+++ b/src/lmd/lib/_segmentation.py
@@ -115,7 +115,7 @@ class SegmentationLoader:
             # valid options are ["none", "hilbert", "greedy"]
             path_optimization: "hilbert"
 
-            # Paramter required for hilbert curve based path optimization.
+            # Parameter required for hilbert curve based path optimization.
             # Defines the order of the hilbert curve used, which needs to be tuned with the total cutting area.
             # For areas of 1 x 1 mm we recommend at least p = 4,  for whole slides we recommend p = 7.
             hilbert_p: 7
@@ -123,7 +123,7 @@ class SegmentationLoader:
             # Parameter required for greedy path optimization.
             # Instead of a global distance matrix, the k nearest neighbours are approximated.
             # The optimization problem is then greedily solved for the known set of nearest neighbours until the first set of neighbours is exhausted.
-            # Established edges are then removed and the nearest neighbour approximation is recursivly repeated.
+            # Established edges are then removed and the nearest neighbour approximation is recursively repeated.
             greedy_k: 20
 
             # Overlapping shapes are merged based on a nearest neighbour heuristic.

--- a/src/lmd/lib/_segmentation.py
+++ b/src/lmd/lib/_segmentation.py
@@ -18,13 +18,8 @@ import scipy
 from scipy.spatial import cKDTree
 from tqdm.auto import tqdm
 
-from lmd.segmentation import (
-    _create_coord_index_sparse,
-    calc_len,
-    get_coordinate_form,
-    tsp_greedy_solve,
-    tsp_hilbert_solve,
-)
+from lmd.path import calc_len, tsp_greedy_solve, tsp_hilbert_solve
+from lmd.segmentation import _create_coord_index_sparse, get_coordinate_form
 
 from ._geom import Collection
 from ._utils import _create_poly, _execute_indexed_parallel, transform_to_map

--- a/src/lmd/lib/_segmentation.py
+++ b/src/lmd/lib/_segmentation.py
@@ -16,13 +16,8 @@ import scipy
 from scipy.spatial import cKDTree
 from tqdm.auto import tqdm
 
-from lmd.segmentation import (
-    _create_coord_index_sparse,
-    calc_len,
-    get_coordinate_form,
-    tsp_greedy_solve,
-    tsp_hilbert_solve,
-)
+from lmd.path import calc_len, tsp_greedy_solve, tsp_hilbert_solve
+from lmd.segmentation import _create_coord_index_sparse, get_coordinate_form
 
 from ._geom import Collection
 from ._utils import _create_poly, _execute_indexed_parallel, transform_to_map

--- a/src/lmd/lib/_segmentation.py
+++ b/src/lmd/lib/_segmentation.py
@@ -5,8 +5,6 @@ import multiprocessing as mp
 import os
 import platform
 import sys
-
-# import warnings
 import warnings
 from functools import partial, reduce
 from pathlib import Path

--- a/src/lmd/lib/_utils.py
+++ b/src/lmd/lib/_utils.py
@@ -5,8 +5,6 @@ from typing import Callable
 
 import matplotlib.pyplot as plt
 import numpy as np
-
-# import warnings
 from rdp import rdp
 from scipy import ndimage
 from scipy.signal import convolve2d

--- a/src/lmd/lib/_utils.py
+++ b/src/lmd/lib/_utils.py
@@ -48,7 +48,7 @@ def _execute_indexed_parallel(func: Callable, *, args: list, tqdm_args: dict = N
 # TODO: Add type hints
 # TODO: Add docstring to public method
 def transform_to_map(coords, dilation=0, erosion=0, coord_format=True, debug=False):
-    # safety boundary which extands the generated map size
+    # safety boundary which extends the generated map size
     safety_offset = 3
     dilation_offset = int(dilation)
 

--- a/src/lmd/path.py
+++ b/src/lmd/path.py
@@ -94,10 +94,9 @@ def _get_closest(used, choices, world_size):
     # all choices have been taken, return closest free index due to local optimality
 
 
-# TODO: Rename to TSP (traveling sales person)
 # TODO: Add type hints
 # TODO: Add umap as optional dependency
-def _tps_greedy_solve(data, k=100):
+def _tsp_greedy_solve(data, k=100):
     samples = len(data)
 
     print(f"{samples} nodes left")
@@ -139,7 +138,7 @@ def _tps_greedy_solve(data, k=100):
 
     # join lists
 
-    return np.concatenate([data[nodes], _tps_greedy_solve(node_data_left, k=k)])
+    return np.concatenate([data[nodes], _tsp_greedy_solve(node_data_left, k=k)])
 
 
 # TODO: Add type hints
@@ -175,7 +174,7 @@ def tsp_greedy_solve(node_list, k=100, return_sorted=False):
 
     """
 
-    sorted_nodes = _tps_greedy_solve(node_list)
+    sorted_nodes = _tsp_greedy_solve(node_list)
 
     if return_sorted:
         return sorted_nodes

--- a/src/lmd/path.py
+++ b/src/lmd/path.py
@@ -1,0 +1,185 @@
+"""Path optimization utilities for LMD cutting path generation.
+
+This module provides algorithms for solving the Traveling Salesman Problem (TSP)
+to optimize the order of cutting shapes, minimizing total travel distance for
+laser microdissection operations.
+
+Functions:
+    tsp_hilbert_solve: Hilbert curve-based TSP approximation
+    tsp_greedy_solve: Greedy k-NN based TSP approximation
+    calc_len: Calculate total path length from coordinates
+"""
+
+import numpy as np
+from hilbertcurve.hilbertcurve import HilbertCurve
+from numba import njit
+
+
+def calc_len(data):
+    """calculate the length of a path based on a list of coordinates
+
+    Args:
+        data (np.array): Array of shape `(N, 2)` containing a list of coordinates
+
+    """
+
+    index = np.arange(len(data)).astype(int)
+
+    not_shifted = data[index[:-1]]
+    shifted = data[index[1:]]
+
+    diff = not_shifted - shifted
+    sq = np.square(diff)
+    dist = np.sum(np.sqrt(np.sum(sq, axis=1)))
+
+    return dist
+
+
+@njit()
+def assign_vertices(hilbert_points, data_rounded):
+    data_rounded = data_rounded.astype(np.int64)
+    hilbert_points = hilbert_points.astype(np.int64)
+
+    output_order = np.zeros(len(data_rounded)).astype(np.int64)
+    current_index = 0
+
+    for hilbert_point in hilbert_points:
+        for i, data_point in enumerate(data_rounded):
+            if np.array_equal(hilbert_point, data_point):
+                output_order[current_index] = i
+                current_index += 1
+
+    return output_order
+
+
+def tsp_hilbert_solve(data, p=3):
+    p = p
+    n = 2
+    max_n = 2 ** (p * n)
+    hilbert_curve = HilbertCurve(p, n)
+    distances = list(range(max_n))
+    hilbert_points = hilbert_curve.points_from_distances(distances)
+    hilbert_points = np.array(hilbert_points)
+
+    data_min = np.min(data, axis=0)
+    data_max = np.max(data, axis=0)
+
+    hilbert_min = np.min(hilbert_points, axis=0)
+    hilbert_max = np.max(hilbert_points, axis=0)
+
+    data_scaled = data - data_min
+    data_scaled = data_scaled / (data_max - data_min) * (hilbert_max - hilbert_min)
+
+    data_rounded = np.round(data_scaled).astype(int)
+
+    order = assign_vertices(hilbert_points, data_rounded)
+
+    return order
+
+
+# TODO: Remove unused argument `world_size`
+# TODO: Add type hints
+# TODO: Add docstrings
+# return the first element not present in a list
+def _get_closest(used, choices, world_size):
+    for element in choices:
+        if element not in used:
+            # knn matrix contains -1 if the number of elements is smaller than k
+            if element == -1:
+                return None
+            else:
+                return element
+
+    return None
+    # all choices have been taken, return closest free index due to local optimality
+
+
+# TODO: Rename to TSP (traveling sales person)
+# TODO: Add type hints
+# TODO: Add umap as optional dependency
+def _tps_greedy_solve(data, k=100):
+    samples = len(data)
+
+    print(f"{samples} nodes left")
+    # recursive abort
+    if samples == 1:
+        return data
+
+    import umap
+
+    knn_index, knn_dist, _ = umap.umap_.nearest_neighbors(
+        data, n_neighbors=k, metric="euclidean", metric_kwds={}, angular=True, random_state=np.random.RandomState(42)
+    )
+
+    knn_index = knn_index[:, 1:]
+    knn_dist = knn_dist[:, 1:]
+
+    # follow greedy knn as long as a nearest neighbour is found in the current tree
+    nodes = []
+    current_node = 0
+    while current_node is not None:
+        nodes.append(current_node)
+        # print(current_node, knn_index[current_node], next_node)
+        next_node = _get_closest(nodes, knn_index[current_node], samples)
+
+        current_node = next_node
+
+    # as soon as no nearest neigbour can be found, create a new list of all elements still remeining
+    # nodes: [0, 2, 5], nodes_left: [1, 3, 4, 6, 7, 8, 9]
+    # add the last node assigned as starting point to the new list
+    # nodes: [0, 2], nodes_left: [5, 1, 3, 4, 6, 7, 8, 9]
+
+    nodes_left = list(set(range(samples)) - set(nodes))
+
+    # add last node from nodes to nodes_left
+
+    nodes_left = [nodes.pop(-1)] + nodes_left
+
+    node_data_left = data[nodes_left]
+
+    # join lists
+
+    return np.concatenate([data[nodes], _tps_greedy_solve(node_data_left, k=k)])
+
+
+# TODO: Add type hints
+# TODO: Add docstrings
+# calculate the index array for a sorted 2d list based on an unsorted list
+@njit()
+def _get_nodes(data, sorted_data):
+    indexed_data = list(enumerate(data))
+
+    nodes = []
+
+    print("start sorting")
+    for element in sorted_data:
+        for j, tup in enumerate(indexed_data):
+            i, el = tup
+
+            if np.array_equal(el, element):
+                nodes.append(i)
+                indexed_data.pop(j)
+    return nodes
+
+
+# TODO: Add type hints
+def tsp_greedy_solve(node_list, k=100, return_sorted=False):
+    """Find an approximation of the closest path through a list of coordinates
+
+    Args:
+        node_list (np.array): Array of shape `(N, 2)` containing a list of coordinates
+
+        k (int, default: 100): Number of Nearest Neighbours calculated for each Node.
+
+        return_sorted: If set to False a list of indices is returned. If set to True the sorted coordinates are returned.
+
+    """
+
+    sorted_nodes = _tps_greedy_solve(node_list)
+
+    if return_sorted:
+        return sorted_nodes
+
+    else:
+        nodes_order = _get_nodes(node_list, sorted_nodes)
+        return nodes_order

--- a/src/lmd/path.py
+++ b/src/lmd/path.py
@@ -104,7 +104,12 @@ def _tsp_greedy_solve(data, k=100):
     if samples == 1:
         return data
 
-    import umap
+    try:
+        import umap
+    except ImportError:
+        raise ImportError(
+            "umap-learn is required for this function. " "Install it with: pip install py-lmd[umap]"
+        ) from None
 
     knn_index, knn_dist, _ = umap.umap_.nearest_neighbors(
         data, n_neighbors=k, metric="euclidean", metric_kwds={}, angular=True, random_state=np.random.RandomState(42)

--- a/src/lmd/segmentation.py
+++ b/src/lmd/segmentation.py
@@ -6,6 +6,33 @@ import numpy as np
 from numba import njit, prange, types
 from scipy.sparse import coo_array
 
+# =============================================================================
+# Deprecation Aliases - Path Optimization Functions
+# =============================================================================
+# These functions have been moved to lmd.path module.
+# Imports from lmd.segmentation are deprecated and will be removed in v3.0.0
+from lmd.path import (
+    _get_closest as __get_closest,
+)
+from lmd.path import (
+    _get_nodes as __get_nodes,
+)
+from lmd.path import (
+    _tps_greedy_solve as __tps_greedy_solve,
+)
+from lmd.path import (
+    assign_vertices as _assign_vertices,
+)
+from lmd.path import (
+    calc_len as _calc_len,
+)
+from lmd.path import (
+    tsp_greedy_solve as _tsp_greedy_solve,
+)
+from lmd.path import (
+    tsp_hilbert_solve as _tsp_hilbert_solve,
+)
+
 # TODO: Rename index_list to index_dict to correctly represent type
 # TODO: Rename index_list to index_dict to correctly represent type
 
@@ -152,35 +179,6 @@ def get_coordinate_form(classes, coords_lookup, debug=False):
     length = [len(el) for el in coords_filtered]
 
     return center, length, coords_filtered
-
-
-# =============================================================================
-# Deprecation Aliases - Path Optimization Functions
-# =============================================================================
-# These functions have been moved to lmd.path module.
-# Imports from lmd.segmentation are deprecated and will be removed in v3.0.0
-
-from lmd.path import (
-    _get_closest as __get_closest,
-)
-from lmd.path import (
-    _get_nodes as __get_nodes,
-)
-from lmd.path import (
-    _tps_greedy_solve as __tps_greedy_solve,
-)
-from lmd.path import (
-    assign_vertices as _assign_vertices,
-)
-from lmd.path import (
-    calc_len as _calc_len,
-)
-from lmd.path import (
-    tsp_greedy_solve as _tsp_greedy_solve,
-)
-from lmd.path import (
-    tsp_hilbert_solve as _tsp_hilbert_solve,
-)
 
 
 def calc_len(data):

--- a/src/lmd/segmentation.py
+++ b/src/lmd/segmentation.py
@@ -1,8 +1,8 @@
 import gc
+import warnings
 
 import numba as nb
 import numpy as np
-from hilbertcurve.hilbertcurve import HilbertCurve
 from numba import njit, prange, types
 from scipy.sparse import coo_array
 
@@ -154,171 +154,114 @@ def get_coordinate_form(classes, coords_lookup, debug=False):
     return center, length, coords_filtered
 
 
-def tsp_hilbert_solve(data, p=3):
-    p = p
-    n = 2
-    max_n = 2 ** (p * n)
-    hilbert_curve = HilbertCurve(p, n)
-    distances = list(range(max_n))
-    hilbert_points = hilbert_curve.points_from_distances(distances)
-    hilbert_points = np.array(hilbert_points)
+# =============================================================================
+# Deprecation Aliases - Path Optimization Functions
+# =============================================================================
+# These functions have been moved to lmd.path module.
+# Imports from lmd.segmentation are deprecated and will be removed in v3.0.0
 
-    data_min = np.min(data, axis=0)
-    data_max = np.max(data, axis=0)
-
-    hilbert_min = np.min(hilbert_points, axis=0)
-    hilbert_max = np.max(hilbert_points, axis=0)
-
-    data_scaled = data - data_min
-    data_scaled = data_scaled / (data_max - data_min) * (hilbert_max - hilbert_min)
-
-    data_rounded = np.round(data_scaled).astype(int)
-
-    order = assign_vertices(hilbert_points, data_rounded)
-
-    return order
-
-
-# TODO: Remove unused argument `world_size`
-# TODO: Add type hints
-# TODO: Add docstrings
-# return the first element not present in a list
-def _get_closest(used, choices, world_size):
-    for element in choices:
-        if element not in used:
-            # knn matrix contains -1 if the number of elements is smaller than k
-            if element == -1:
-                return None
-            else:
-                return element
-
-    return None
-    # all choices have been taken, return closest free index due to local optimality
-
-
-# TODO: Rename to TSP (traveling sales person)
-# TODO: Add type hints
-# TODO: Add umap as optional dependency
-def _tps_greedy_solve(data, k=100):
-    samples = len(data)
-
-    print(f"{samples} nodes left")
-    # recursive abort
-    if samples == 1:
-        return data
-
-    import umap
-
-    knn_index, knn_dist, _ = umap.umap_.nearest_neighbors(
-        data, n_neighbors=k, metric="euclidean", metric_kwds={}, angular=True, random_state=np.random.RandomState(42)
-    )
-
-    knn_index = knn_index[:, 1:]
-    knn_dist = knn_dist[:, 1:]
-
-    # follow greedy knn as long as a nearest neighbour is found in the current tree
-    nodes = []
-    current_node = 0
-    while current_node is not None:
-        nodes.append(current_node)
-        # print(current_node, knn_index[current_node], next_node)
-        next_node = _get_closest(nodes, knn_index[current_node], samples)
-
-        current_node = next_node
-
-    # as soon as no nearest neigbour can be found, create a new list of all elements still remeining
-    # nodes: [0, 2, 5], nodes_left: [1, 3, 4, 6, 7, 8, 9]
-    # add the last node assigned as starting point to the new list
-    # nodes: [0, 2], nodes_left: [5, 1, 3, 4, 6, 7, 8, 9]
-
-    nodes_left = list(set(range(samples)) - set(nodes))
-
-    # add last node from nodes to nodes_left
-
-    nodes_left = [nodes.pop(-1)] + nodes_left
-
-    node_data_left = data[nodes_left]
-
-    # join lists
-
-    return np.concatenate([data[nodes], _tps_greedy_solve(node_data_left, k=k)])
-
-
-# TODO: Add type hints
-# TODO: Add docstrings
-# calculate the index array for a sorted 2d list based on an unsorted list
-@njit()
-def _get_nodes(data, sorted_data):
-    indexed_data = list(enumerate(data))
-
-    nodes = []
-
-    print("start sorting")
-    for element in sorted_data:
-        for j, tup in enumerate(indexed_data):
-            i, el = tup
-
-            if np.array_equal(el, element):
-                nodes.append(i)
-                indexed_data.pop(j)
-    return nodes
-
-
-# TODO: Add type hints
-def tsp_greedy_solve(node_list, k=100, return_sorted=False):
-    """Find an approximation of the closest path through a list of coordinates
-
-    Args:
-        node_list (np.array): Array of shape `(N, 2)` containing a list of coordinates
-
-        k (int, default: 100): Number of Nearest Neighbours calculated for each Node.
-
-        return_sorted: If set to False a list of indices is returned. If set to True the sorted coordinates are returned.
-
-    """
-
-    sorted_nodes = _tps_greedy_solve(node_list)
-
-    if return_sorted:
-        return sorted_nodes
-
-    else:
-        nodes_order = _get_nodes(node_list, sorted_nodes)
-        return nodes_order
-
-
-@njit()
-def assign_vertices(hilbert_points, data_rounded):
-    data_rounded = data_rounded.astype(np.int64)
-    hilbert_points = hilbert_points.astype(np.int64)
-
-    output_order = np.zeros(len(data_rounded)).astype(np.int64)
-    current_index = 0
-
-    for hilbert_point in hilbert_points:
-        for i, data_point in enumerate(data_rounded):
-            if np.array_equal(hilbert_point, data_point):
-                output_order[current_index] = i
-                current_index += 1
-
-    return output_order
+from lmd.path import (
+    _get_closest as __get_closest,
+)
+from lmd.path import (
+    _get_nodes as __get_nodes,
+)
+from lmd.path import (
+    _tps_greedy_solve as __tps_greedy_solve,
+)
+from lmd.path import (
+    assign_vertices as _assign_vertices,
+)
+from lmd.path import (
+    calc_len as _calc_len,
+)
+from lmd.path import (
+    tsp_greedy_solve as _tsp_greedy_solve,
+)
+from lmd.path import (
+    tsp_hilbert_solve as _tsp_hilbert_solve,
+)
 
 
 def calc_len(data):
-    """calculate the length of a path based on a list of coordinates
+    """Deprecated: Use lmd.path.calc_len instead."""
+    warnings.warn(
+        "calc_len has been moved to lmd.path. "
+        "Import from lmd.segmentation is deprecated and will be removed in v3.0.0. "
+        "Please use: from lmd.path import calc_len",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _calc_len(data)
 
-    Args:
-        data (np.array): Array of shape `(N, 2)` containing a list of coordinates
 
-    """
+def tsp_hilbert_solve(data, p=3):
+    """Deprecated: Use lmd.path.tsp_hilbert_solve instead."""
+    warnings.warn(
+        "tsp_hilbert_solve has been moved to lmd.path. "
+        "Import from lmd.segmentation is deprecated and will be removed in v3.0.0. "
+        "Please use: from lmd.path import tsp_hilbert_solve",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _tsp_hilbert_solve(data, p=p)
 
-    index = np.arange(len(data)).astype(int)
 
-    not_shifted = data[index[:-1]]
-    shifted = data[index[1:]]
+def tsp_greedy_solve(node_list, k=100, return_sorted=False):
+    """Deprecated: Use lmd.path.tsp_greedy_solve instead."""
+    warnings.warn(
+        "tsp_greedy_solve has been moved to lmd.path. "
+        "Import from lmd.segmentation is deprecated and will be removed in v3.0.0. "
+        "Please use: from lmd.path import tsp_greedy_solve",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _tsp_greedy_solve(node_list, k=k, return_sorted=return_sorted)
 
-    diff = not_shifted - shifted
-    sq = np.square(diff)
-    dist = np.sum(np.sqrt(np.sum(sq, axis=1)))
 
-    return dist
+def assign_vertices(hilbert_points, data_rounded):
+    """Deprecated: Use lmd.path.assign_vertices instead."""
+    warnings.warn(
+        "assign_vertices has been moved to lmd.path. "
+        "Import from lmd.segmentation is deprecated and will be removed in v3.0.0. "
+        "Please use: from lmd.path import assign_vertices",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _assign_vertices(hilbert_points, data_rounded)
+
+
+def _get_closest(used, choices, world_size):
+    """Deprecated: Use lmd.path._get_closest instead."""
+    warnings.warn(
+        "_get_closest has been moved to lmd.path. "
+        "Import from lmd.segmentation is deprecated and will be removed in v3.0.0. "
+        "Please use: from lmd.path import _get_closest",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return __get_closest(used, choices, world_size)
+
+
+def _get_nodes(data, sorted_data):
+    """Deprecated: Use lmd.path._get_nodes instead."""
+    warnings.warn(
+        "_get_nodes has been moved to lmd.path. "
+        "Import from lmd.segmentation is deprecated and will be removed in v3.0.0. "
+        "Please use: from lmd.path import _get_nodes",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return __get_nodes(data, sorted_data)
+
+
+def _tps_greedy_solve(data, k=100):
+    """Deprecated: Use lmd.path._tps_greedy_solve instead."""
+    warnings.warn(
+        "_tps_greedy_solve has been moved to lmd.path. "
+        "Import from lmd.segmentation is deprecated and will be removed in v3.0.0. "
+        "Please use: from lmd.path import _tps_greedy_solve",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return __tps_greedy_solve(data, k=k)

--- a/src/lmd/segmentation.py
+++ b/src/lmd/segmentation.py
@@ -18,7 +18,7 @@ from lmd.path import (
     _get_nodes as __get_nodes,
 )
 from lmd.path import (
-    _tps_greedy_solve as __tps_greedy_solve,
+    _tsp_greedy_solve as __tsp_greedy_solve,
 )
 from lmd.path import (
     assign_vertices as _assign_vertices,
@@ -254,12 +254,12 @@ def _get_nodes(data, sorted_data):
 
 
 def _tps_greedy_solve(data, k=100):
-    """Deprecated: Use lmd.path._tps_greedy_solve instead."""
+    """Deprecated: Use lmd.path._tsp_greedy_solve instead."""
     warnings.warn(
-        "_tps_greedy_solve has been moved to lmd.path. "
+        "_tps_greedy_solve has been moved to lmd.path and renamed to _tsp_greedy_solve. "
         "Import from lmd.segmentation is deprecated and will be removed in v3.0.0. "
-        "Please use: from lmd.path import _tps_greedy_solve",
+        "Please use: from lmd.path import _tsp_greedy_solve",
         DeprecationWarning,
         stacklevel=2,
     )
-    return __tps_greedy_solve(data, k=k)
+    return __tsp_greedy_solve(data, k=k)

--- a/tests/unit/test_lmd/test_lib/test_lib_utils.py
+++ b/tests/unit/test_lmd/test_lib/test_lib_utils.py
@@ -96,7 +96,7 @@ class TestTransformToMap:
     @pytest.mark.parametrize(
         ("coords",),
         [(np.array([[0, 0]]),), (np.array([[2, 1]]),), (np.array([[0, 0], [2, 1]]),)],
-        ids=("simple", "assymmetric", "multiple_coords"),
+        ids=("simple", "asymmetric", "multiple_coords"),
     )
     def test_transform_to_map__no_changes__coord_format(self, coords: np.ndarray) -> None:
         """Test that `coord_format=True` just returns the coords if no dilation/erosion is applied"""
@@ -119,7 +119,7 @@ class TestTransformToMap:
                 np.array([[0, 0], [100, 100]]),
             ),  # boundary left/right, no offset
         ],
-        ids=("simple", "assymmetric", "multiple_coords", "with_offsets", "large_without_offsets"),
+        ids=("simple", "asymmetric", "multiple_coords", "with_offsets", "large_without_offsets"),
     )
     def test_transform_to_map__no_changes__mask_format(
         self,

--- a/tests/unit/test_lmd/test_path.py
+++ b/tests/unit/test_lmd/test_path.py
@@ -1,0 +1,170 @@
+"""Tests for lmd.path module - path optimization functions."""
+
+from typing import Optional
+
+import numpy as np
+import pytest
+
+from lmd.path import (
+    _get_closest,
+    _get_nodes,
+    assign_vertices,
+    calc_len,
+    tsp_hilbert_solve,
+)
+
+ATOL = 1e-10
+
+
+@pytest.mark.parametrize(
+    ("data", "p"),
+    [
+        # Two points - should return valid ordering
+        (np.array([[0.0, 0.0], [1.0, 1.0]]), 3),
+        # Four corner points
+        (np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]]), 3),
+        # Linear points
+        (np.array([[0.0, 0.0], [0.5, 0.5], [1.0, 1.0]]), 3),
+        # More points with different p value
+        (np.array([[0.0, 0.0], [0.25, 0.25], [0.5, 0.5], [0.75, 0.75], [1.0, 1.0]]), 4),
+    ],
+    ids=("two_points", "four_corners", "linear_points", "five_points_p4"),
+)
+def test_tsp_hilbert_solve(data: np.ndarray, p: int) -> None:
+    """Test `tsp_hilbert_solve` returns valid ordering"""
+    # Act
+    result = tsp_hilbert_solve(data=data, p=p)
+
+    # Assert - result should be a permutation of indices
+    assert len(result) == len(data)
+    assert set(result) == set(range(len(data)))
+
+
+@pytest.mark.parametrize(
+    ("used", "choices", "world_size", "expected_result"),
+    [
+        # First element not in used is returned
+        ([], [0, 1, 2], 10, 0),
+        # First element is used, return second
+        ([0], [0, 1, 2], 10, 1),
+        # First two elements used, return third
+        ([0, 1], [0, 1, 2], 10, 2),
+        # All elements are used, return None
+        ([0, 1, 2], [0, 1, 2], 10, None),
+        # First available element is -1, return None
+        ([0], [0, -1, 2], 10, None),
+        # -1 at start and not in used returns None
+        ([], [-1, 1, 2], 10, None),
+        # Skip used elements to find first available
+        ([0, 2], [0, 2, 1, 3], 10, 1),
+        # Empty choices returns None
+        ([0], [], 10, None),
+    ],
+    ids=(
+        "first_available",
+        "skip_one_used",
+        "skip_two_used",
+        "all_used",
+        "minus_one_element",
+        "minus_one_first",
+        "non_sequential_choices",
+        "empty_choices",
+    ),
+)
+def test__get_closest(used: list[int], choices: list[int], world_size: int, expected_result: Optional[int]) -> None:
+    """Test `_get_closest` for finding first unused element from choices"""
+    # Act
+    result = _get_closest(used=used, choices=choices, world_size=world_size)
+
+    # Assert
+    assert result == expected_result
+
+
+# TODO: Rename test when fixing function name
+# Note: _tps_greedy_solve and tsp_greedy_solve require umap dependency and are tested in integration tests
+
+
+@pytest.mark.parametrize(
+    ("data", "sorted_data", "expected_nodes"),
+    [
+        # Single element
+        (np.array([[0, 0]]), np.array([[0, 0]]), [0]),
+        # Already sorted - indices are 0, 1, 2
+        (
+            np.array([[0, 0], [1, 1], [2, 2]]),
+            np.array([[0, 0], [1, 1], [2, 2]]),
+            [0, 1, 2],
+        ),
+        # Reversed order - indices map sorted back to original positions
+        (
+            np.array([[2, 2], [1, 1], [0, 0]]),
+            np.array([[0, 0], [1, 1], [2, 2]]),
+            [2, 1, 0],
+        ),
+        # Arbitrary reordering
+        (
+            np.array([[1, 0], [0, 1], [2, 2], [0, 0]]),
+            np.array([[0, 0], [1, 0], [0, 1], [2, 2]]),
+            [3, 0, 1, 2],
+        ),
+    ],
+    ids=("single_element", "already_sorted", "reversed", "arbitrary_reorder"),
+)
+def test__get_nodes(data: np.ndarray, sorted_data: np.ndarray, expected_nodes: list[int]) -> None:
+    """Test `_get_nodes` for calculating index array mapping sorted to original data"""
+    result = _get_nodes(data=data, sorted_data=sorted_data)
+
+    assert list(result) == expected_nodes
+
+
+@pytest.mark.parametrize(
+    ("hilbert_points", "data_rounded", "expected_order"),
+    [
+        # Single point
+        (np.array([[0, 0]]), np.array([[0, 0]]), np.array([0])),
+        # Two points in hilbert order
+        (np.array([[0, 0], [1, 0]]), np.array([[0, 0], [1, 0]]), np.array([0, 1])),
+        # Two points in reverse hilbert order - order reflects hilbert traversal
+        (np.array([[0, 0], [1, 0]]), np.array([[1, 0], [0, 0]]), np.array([1, 0])),
+        # Three points with reordering
+        (
+            np.array([[0, 0], [0, 1], [1, 1]]),
+            np.array([[1, 1], [0, 0], [0, 1]]),
+            np.array([1, 2, 0]),
+        ),
+        # Points not all on hilbert curve - only matching points are ordered
+        (
+            np.array([[0, 0], [1, 0], [2, 0]]),
+            np.array([[0, 0], [2, 0]]),
+            np.array([0, 1]),
+        ),
+    ],
+    ids=(
+        "single_point",
+        "two_points_in_order",
+        "two_points_reversed",
+        "three_points_reorder",
+        "partial_match",
+    ),
+)
+def test_assign_vertices(hilbert_points: np.ndarray, data_rounded: np.ndarray, expected_order: np.ndarray) -> None:
+    """Test `assign_vertices` for ordering data points along hilbert curve"""
+    result = assign_vertices(hilbert_points=hilbert_points, data_rounded=data_rounded)
+
+    assert np.array_equal(result[: len(expected_order)], expected_order)
+
+
+@pytest.mark.parametrize(
+    ("array", "expected_result"),
+    [
+        (np.array([[0], [1], [2]]), 2),
+        (np.array([[0, 0], [1, 0], [2, 0]]), 2),
+        (np.array([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]), 4),
+    ],
+    ids=("1d_like", "linear", "square_circular_path"),
+)
+def test_calc_len(array: np.ndarray, expected_result: float) -> None:
+    """Test `calc_len` for the computation of a path length"""
+    result = calc_len(array)
+
+    assert result == expected_result

--- a/tests/unit/test_lmd/test_segmentation.py
+++ b/tests/unit/test_lmd/test_segmentation.py
@@ -1,4 +1,4 @@
-from typing import Optional
+import warnings
 
 import numpy as np
 import pytest
@@ -7,13 +7,8 @@ from lmd.segmentation import (
     _create_coord_index,
     _create_coord_index_sparse,
     _filter_coord_index,
-    _get_closest,
-    _get_nodes,
     _numba_accelerator_coord_calculation,
-    assign_vertices,
-    calc_len,
     get_coordinate_form,
-    tsp_hilbert_solve,
 )
 
 ATOL = 1e-10
@@ -251,155 +246,99 @@ def test_get_coordinate_form(
         assert np.allclose(cf, ecf, atol=ATOL)
 
 
-@pytest.mark.parametrize(
-    ("data", "p"),
-    [
-        # Two points - should return valid ordering
-        (np.array([[0.0, 0.0], [1.0, 1.0]]), 3),
-        # Four corner points
-        (np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]]), 3),
-        # Linear points
-        (np.array([[0.0, 0.0], [0.5, 0.5], [1.0, 1.0]]), 3),
-        # More points with different p value
-        (np.array([[0.0, 0.0], [0.25, 0.25], [0.5, 0.5], [0.75, 0.75], [1.0, 1.0]]), 4),
-    ],
-    ids=("two_points", "four_corners", "linear_points", "five_points_p4"),
-)
-def test_tsp_hilbert_solve(data: np.ndarray, p: int) -> None:
-    """Test `tsp_hilbert_solve` returns valid ordering"""
-    # Act
-    result = tsp_hilbert_solve(data=data, p=p)
-
-    # Assert - result should be a permutation of indices
-    assert len(result) == len(data)
-    assert set(result) == set(range(len(data)))
+# =============================================================================
+# Deprecation Warning Tests
+# =============================================================================
+# These tests verify that importing path functions from lmd.segmentation
+# raises deprecation warnings. The actual function tests are in test_path.py.
 
 
-@pytest.mark.parametrize(
-    ("used", "choices", "world_size", "expected_result"),
-    [
-        # First element not in used is returned
-        ([], [0, 1, 2], 10, 0),
-        # First element is used, return second
-        ([0], [0, 1, 2], 10, 1),
-        # First two elements used, return third
-        ([0, 1], [0, 1, 2], 10, 2),
-        # All elements are used, return None
-        ([0, 1, 2], [0, 1, 2], 10, None),
-        # First available element is -1, return None
-        ([0], [0, -1, 2], 10, None),
-        # -1 at start and not in used returns None
-        ([], [-1, 1, 2], 10, None),
-        # Skip used elements to find first available
-        ([0, 2], [0, 2, 1, 3], 10, 1),
-        # Empty choices returns None
-        ([0], [], 10, None),
-    ],
-    ids=(
-        "first_available",
-        "skip_one_used",
-        "skip_two_used",
-        "all_used",
-        "minus_one_element",
-        "minus_one_first",
-        "non_sequential_choices",
-        "empty_choices",
-    ),
-)
-def test__get_closest(used: list[int], choices: list[int], world_size: int, expected_result: Optional[int]) -> None:
-    """Test `_get_closest` for finding first unused element from choices"""
-    # Act
-    result = _get_closest(used=used, choices=choices, world_size=world_size)
+class TestDeprecationWarnings:
+    """Test that deprecated imports from lmd.segmentation raise DeprecationWarning."""
 
-    # Assert
-    assert result == expected_result
+    def test_calc_len_deprecation_warning(self) -> None:
+        """Test that calc_len raises DeprecationWarning when imported from segmentation."""
+        from lmd.segmentation import calc_len
 
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            calc_len(np.array([[0, 0], [1, 1]]))
 
-# TODO: Rename test when fixing function name
-# Note: _tps_greedy_solve and tsp_greedy_solve require umap dependency and are tested in integration tests
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "calc_len has been moved to lmd.path" in str(w[0].message)
 
+    def test_tsp_hilbert_solve_deprecation_warning(self) -> None:
+        """Test that tsp_hilbert_solve raises DeprecationWarning when imported from segmentation."""
+        from lmd.segmentation import tsp_hilbert_solve
 
-@pytest.mark.parametrize(
-    ("data", "sorted_data", "expected_nodes"),
-    [
-        # Single element
-        (np.array([[0, 0]]), np.array([[0, 0]]), [0]),
-        # Already sorted - indices are 0, 1, 2
-        (
-            np.array([[0, 0], [1, 1], [2, 2]]),
-            np.array([[0, 0], [1, 1], [2, 2]]),
-            [0, 1, 2],
-        ),
-        # Reversed order - indices map sorted back to original positions
-        (
-            np.array([[2, 2], [1, 1], [0, 0]]),
-            np.array([[0, 0], [1, 1], [2, 2]]),
-            [2, 1, 0],
-        ),
-        # Arbitrary reordering
-        (
-            np.array([[1, 0], [0, 1], [2, 2], [0, 0]]),
-            np.array([[0, 0], [1, 0], [0, 1], [2, 2]]),
-            [3, 0, 1, 2],
-        ),
-    ],
-    ids=("single_element", "already_sorted", "reversed", "arbitrary_reorder"),
-)
-def test__get_nodes(data: np.ndarray, sorted_data: np.ndarray, expected_nodes: list[int]) -> None:
-    """Test `_get_nodes` for calculating index array mapping sorted to original data"""
-    result = _get_nodes(data=data, sorted_data=sorted_data)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            tsp_hilbert_solve(np.array([[0.0, 0.0], [1.0, 1.0]]), p=3)
 
-    assert list(result) == expected_nodes
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "tsp_hilbert_solve has been moved to lmd.path" in str(w[0].message)
 
+    def test_tsp_greedy_solve_deprecation_warning(self) -> None:
+        """Test that tsp_greedy_solve raises DeprecationWarning when imported from segmentation."""
+        from lmd.segmentation import tsp_greedy_solve
 
-@pytest.mark.parametrize(
-    ("hilbert_points", "data_rounded", "expected_order"),
-    [
-        # Single point
-        (np.array([[0, 0]]), np.array([[0, 0]]), np.array([0])),
-        # Two points in hilbert order
-        (np.array([[0, 0], [1, 0]]), np.array([[0, 0], [1, 0]]), np.array([0, 1])),
-        # Two points in reverse hilbert order - order reflects hilbert traversal
-        (np.array([[0, 0], [1, 0]]), np.array([[1, 0], [0, 0]]), np.array([1, 0])),
-        # Three points with reordering
-        (
-            np.array([[0, 0], [0, 1], [1, 1]]),
-            np.array([[1, 1], [0, 0], [0, 1]]),
-            np.array([1, 2, 0]),
-        ),
-        # Points not all on hilbert curve - only matching points are ordered
-        (
-            np.array([[0, 0], [1, 0], [2, 0]]),
-            np.array([[0, 0], [2, 0]]),
-            np.array([0, 1]),
-        ),
-    ],
-    ids=(
-        "single_point",
-        "two_points_in_order",
-        "two_points_reversed",
-        "three_points_reorder",
-        "partial_match",
-    ),
-)
-def test_assign_vertices(hilbert_points: np.ndarray, data_rounded: np.ndarray, expected_order: np.ndarray) -> None:
-    """Test `assign_vertices` for ordering data points along hilbert curve"""
-    result = assign_vertices(hilbert_points=hilbert_points, data_rounded=data_rounded)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            # Note: tsp_greedy_solve requires umap, so we just check the warning is raised
+            # before the actual call would happen
+            tsp_greedy_solve(np.array([[0.0, 0.0], [1.0, 1.0]]))
 
-    assert np.array_equal(result[: len(expected_order)], expected_order)
+            assert len(w) >= 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "tsp_greedy_solve has been moved to lmd.path" in str(w[0].message)
 
+    def test_assign_vertices_deprecation_warning(self) -> None:
+        """Test that assign_vertices raises DeprecationWarning when imported from segmentation."""
+        from lmd.segmentation import assign_vertices
 
-@pytest.mark.parametrize(
-    ("array", "expected_result"),
-    [
-        (np.array([[0], [1], [2]]), 2),
-        (np.array([[0, 0], [1, 0], [2, 0]]), 2),
-        (np.array([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]), 4),
-    ],
-    ids=("1d_like", "linear", "square_circular_path"),
-)
-def test_calc_len(array: np.ndarray, expected_result: float) -> None:
-    """Test `calc_len` for the computation of a path length"""
-    result = calc_len(array)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            assign_vertices(np.array([[0, 0]]), np.array([[0, 0]]))
 
-    assert result == expected_result
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "assign_vertices has been moved to lmd.path" in str(w[0].message)
+
+    def test__get_closest_deprecation_warning(self) -> None:
+        """Test that _get_closest raises DeprecationWarning when imported from segmentation."""
+        from lmd.segmentation import _get_closest
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _get_closest([], [0, 1, 2], 10)
+
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "_get_closest has been moved to lmd.path" in str(w[0].message)
+
+    def test__get_nodes_deprecation_warning(self) -> None:
+        """Test that _get_nodes raises DeprecationWarning when imported from segmentation."""
+        from lmd.segmentation import _get_nodes
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _get_nodes(np.array([[0, 0]]), np.array([[0, 0]]))
+
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "_get_nodes has been moved to lmd.path" in str(w[0].message)
+
+    def test__tps_greedy_solve_deprecation_warning(self) -> None:
+        """Test that _tps_greedy_solve raises DeprecationWarning when imported from segmentation."""
+        from lmd.segmentation import _tps_greedy_solve
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            _tps_greedy_solve(np.array([[0.0, 0.0], [1.0, 1.0]]))
+
+            assert len(w) >= 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "_tps_greedy_solve has been moved to lmd.path" in str(w[0].message)


### PR DESCRIPTION
Introduce `lmd.path` module that exposes the path optimization methods. First step towards making the path optimization applicable to other methods. 

`/src/lmd/path.py`
```python
_get_closest
_get_nodes
assign_vertices,
calc_len
_tsp_greedy_solve
tsp_hilbert_solve
tsp_greedy_solve
```

- Maintain old API (re-export methods in lmd.segmentation), but deprecate methods.
- Minimize renaming, only fix typos.  

