### PR TITLE
Add optional UMAP dependency

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install package
       run: |
         pip install uv
-        uv pip install --system ".[tests, dev]"
+        uv pip install --system ".[tests, dev, umap]"
     - name: Run pre-commit checks
       run: |
         pre-commit install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dependencies = {file = ["requirements.txt"]}
 
 [tool.setuptools.dynamic.optional-dependencies]
-umap = {"umap-learn"}
+umap = {file = ["requirements_umap.txt"]}
 dev_only = {file = ["requirements_dev.txt"]}
 doc = {file = ["requirements_doc.txt"]}
 test = {file = ["requirements_test.txt"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 dependencies = {file = ["requirements.txt"]}
 
 [tool.setuptools.dynamic.optional-dependencies]
+umap = {"umap-learn"}
 dev_only = {file = ["requirements_dev.txt"]}
 doc = {file = ["requirements_doc.txt"]}
 test = {file = ["requirements_test.txt"]}

--- a/requirements_umap.txt
+++ b/requirements_umap.txt
@@ -1,0 +1,2 @@
+pre-commit
+pytest

--- a/requirements_umap.txt
+++ b/requirements_umap.txt
@@ -1,2 +1,1 @@
-pre-commit
-pytest
+umap-learn

--- a/src/lmd/path.py
+++ b/src/lmd/path.py
@@ -104,7 +104,12 @@ def _tsp_greedy_solve(data, k=100):
     if samples == 1:
         return data
 
-    import umap
+    try:
+        import umap
+    except ImportError:
+        raise ImportError(
+            "umap-learn is required for this function. " "Install it with: pip install py-lmd[umap]"
+        ) from None
 
     knn_index, knn_dist, _ = umap.umap_.nearest_neighbors(
         data, n_neighbors=k, metric="euclidean", metric_kwds={}, angular=True, random_state=np.random.RandomState(42)


### PR DESCRIPTION
Add umap as optional dependency, which is needed for the `tsp_solver_greedy` and was previously missing. 

The package is an optional dependency `pip install pylmd[umap]`. If it is missing, an `ImportError` is raised.