### PR TITLE
[Fix] Round points instead of flooring

### DIFF
--- a/src/lmd/lib.py
+++ b/src/lmd/lib.py
@@ -477,10 +477,10 @@ class Collection:
 
             id = i + 1
             x = ET.SubElement(root, f"X_CalibrationPoint_{id}")
-            x.text = f"{np.floor(point[0]).astype(int)}"
+            x.text = f"{int(round(point[0], 0))}"
 
             y = ET.SubElement(root, f"Y_CalibrationPoint_{id}")
-            y.text = f"{np.floor(point[1]).astype(int)}"
+            y.text = f"{int(round(point[1], 0))}"
 
         # write shape length
         shape_count = ET.SubElement(root, "ShapeCount")
@@ -687,10 +687,10 @@ class Shape:
         for i, point in enumerate(transformed_points):
             id = i + 1
             x = ET.SubElement(shape, f"X_{id}")
-            x.text = f"{np.floor(point[0]).astype(int)}"
+            x.text = f"{int(round(point[0], 0))}"
 
             y = ET.SubElement(shape, f"Y_{id}")
-            y.text = f"{np.floor(point[1]).astype(int)}"
+            y.text = f"{int(round(point[1], 0))}"
 
         return shape
 


### PR DESCRIPTION
LMD xml files should only contain integer values. 

py-LMD maps floats to integers via `np.floor`. Especially if all coordinates are relatively small and for smalll numerical imprecisions, this can lead to numbers that are very far off from the original number.

Discussed with @sophiamaedler 

## Example
This PR implements strategy 3 

```python

func1 = lambda xi: int(np.floor(xi)) # current strategy 
func2 = int # python integer 
func3 = lambda xi: int(round(xi, 0)) # rounding 

# example coordinates
# note the -1e-14 which is practically 0
x = [-1, -0.9, -0.5, -0.1, -1e-14, 0, 0.1, 0.5, 0.9, 1, 1.1, 1.5]

# func1: [-1, -1, -1, -1, 0, 0, 0, 0, 1, 1, 1] # -1e-14 rounded to -1
# func2:  [-1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1] # -0.9 rounded 0
# func3: [-1, -1, 0, 0, 0, 0, 0, 1, 1, 1, 2] # reasonable rounding results
```
Rounding + integer gives the closest values to the actual coordinates 

