### PR TITLE
[Fix] Fix download function

### DIFF
--- a/src/lmd/_utils.py
+++ b/src/lmd/_utils.py
@@ -108,7 +108,7 @@ def _download(
         else:
             download_to_path.with_name(output_file_name)
 
-    Path(lock_path).unlink()
+    Path(lock_path).unlink(missing_ok=True)
 
 
 def _download_glyphs() -> Path:

--- a/src/lmd/_utils.py
+++ b/src/lmd/_utils.py
@@ -82,7 +82,7 @@ def _download(
             warning = f"File {download_to_path} already exists!"
             if not overwrite:
                 print(warning)
-                Path(lock_path).unlink()
+                Path(lock_path).unlink(missing_ok=True)
                 return
             else:
                 print(f"{warning} Overwriting...")

--- a/src/lmd/lib.py
+++ b/src/lmd/lib.py
@@ -477,10 +477,10 @@ class Collection:
 
             id = i + 1
             x = ET.SubElement(root, f"X_CalibrationPoint_{id}")
-            x.text = f"{np.floor(point[0]).astype(int)}"
+            x.text = f"{int(round(point[0], 0))}"
 
             y = ET.SubElement(root, f"Y_CalibrationPoint_{id}")
-            y.text = f"{np.floor(point[1]).astype(int)}"
+            y.text = f"{int(round(point[1], 0))}"
 
         # write shape length
         shape_count = ET.SubElement(root, "ShapeCount")
@@ -687,10 +687,10 @@ class Shape:
         for i, point in enumerate(transformed_points):
             id = i + 1
             x = ET.SubElement(shape, f"X_{id}")
-            x.text = f"{np.floor(point[0]).astype(int)}"
+            x.text = f"{int(round(point[0], 0))}"
 
             y = ET.SubElement(shape, f"Y_{id}")
-            y.text = f"{np.floor(point[1]).astype(int)}"
+            y.text = f"{int(round(point[1], 0))}"
 
         return shape
 


### PR DESCRIPTION
[Manual fix, summary generated by Claude]

## Problem
The download-dependent tests (test_glyphs, test_segmentation_loader) fail in CI with:
```
  FileNotFoundError: [Errno 2] No such file or directory:
    '.../pylmd_tmp_xxxxxxxxxx.lock'
```
The traceback points at src/lmd/_utils.py:111, after the download has completed successfully (the progress bar reaches 100%).

## Root cause
  _download wraps the download in a with FileLock(lock_path): block, but then also calls Path(lock_path).unlink() manually to clean up the lock file. FileLock manages the lifecycle of its own .lock file, and with the filelock version resolved in CI the lock file is already gone once the context manager exits. The unguarded unlink() therefore raises FileNotFoundError.


## Fix
Make the cleanup tolerant of an already-removed lock file, consistent with the early-return path