### PR TITLE
Fix/deprecation version

### DIFF
--- a/src/lmd/segmentation.py
+++ b/src/lmd/segmentation.py
@@ -11,7 +11,7 @@ from scipy.sparse import coo_array
 # Deprecation Aliases - Path Optimization Functions
 # =============================================================================
 # These functions have been moved to lmd.path module.
-# Imports from lmd.segmentation are deprecated and will be removed in v3.0.0
+# Imports from lmd.segmentation are deprecated and will be removed in v2.0.0
 from lmd.path import (
     _get_closest as __get_closest,
 )
@@ -192,7 +192,7 @@ def calc_len(data: np.ndarray) -> float:
     """Deprecated: Use lmd.path.calc_len instead."""
     warnings.warn(
         "calc_len has been moved to lmd.path. "
-        "Import from lmd.segmentation is deprecated and will be removed in v3.0.0. "
+        "Import from lmd.segmentation is deprecated and will be removed in v2.0.0. "
         "Please use: from lmd.path import calc_len",
         DeprecationWarning,
         stacklevel=2,
@@ -204,7 +204,7 @@ def tsp_hilbert_solve(data: np.ndarray, p: int = 3) -> np.ndarray:
     """Deprecated: Use lmd.path.tsp_hilbert_solve instead."""
     warnings.warn(
         "tsp_hilbert_solve has been moved to lmd.path. "
-        "Import from lmd.segmentation is deprecated and will be removed in v3.0.0. "
+        "Import from lmd.segmentation is deprecated and will be removed in v2.0.0. "
         "Please use: from lmd.path import tsp_hilbert_solve",
         DeprecationWarning,
         stacklevel=2,
@@ -216,7 +216,7 @@ def tsp_greedy_solve(node_list: np.ndarray, k: int = 100, return_sorted: bool = 
     """Deprecated: Use lmd.path.tsp_greedy_solve instead."""
     warnings.warn(
         "tsp_greedy_solve has been moved to lmd.path. "
-        "Import from lmd.segmentation is deprecated and will be removed in v3.0.0. "
+        "Import from lmd.segmentation is deprecated and will be removed in v2.0.0. "
         "Please use: from lmd.path import tsp_greedy_solve",
         DeprecationWarning,
         stacklevel=2,
@@ -228,7 +228,7 @@ def assign_vertices(hilbert_points: np.ndarray, data_rounded: np.ndarray) -> np.
     """Deprecated: Use lmd.path.assign_vertices instead."""
     warnings.warn(
         "assign_vertices has been moved to lmd.path. "
-        "Import from lmd.segmentation is deprecated and will be removed in v3.0.0. "
+        "Import from lmd.segmentation is deprecated and will be removed in v2.0.0. "
         "Please use: from lmd.path import assign_vertices",
         DeprecationWarning,
         stacklevel=2,
@@ -240,7 +240,7 @@ def _get_closest(used: list[T], choices: Union[list[T], np.ndarray], world_size:
     """Deprecated: Use lmd.path._get_closest instead."""
     warnings.warn(
         "_get_closest has been moved to lmd.path. "
-        "Import from lmd.segmentation is deprecated and will be removed in v3.0.0. "
+        "Import from lmd.segmentation is deprecated and will be removed in v2.0.0. "
         "Please use: from lmd.path import _get_closest",
         DeprecationWarning,
         stacklevel=2,
@@ -252,7 +252,7 @@ def _get_nodes(data: np.ndarray, sorted_data: np.ndarray) -> list[int]:
     """Deprecated: Use lmd.path._get_nodes instead."""
     warnings.warn(
         "_get_nodes has been moved to lmd.path. "
-        "Import from lmd.segmentation is deprecated and will be removed in v3.0.0. "
+        "Import from lmd.segmentation is deprecated and will be removed in v2.0.0. "
         "Please use: from lmd.path import _get_nodes",
         DeprecationWarning,
         stacklevel=2,
@@ -264,7 +264,7 @@ def _tps_greedy_solve(data: np.ndarray, k: int = 100) -> np.ndarray:
     """Deprecated: Use lmd.path._tsp_greedy_solve instead."""
     warnings.warn(
         "_tps_greedy_solve has been moved to lmd.path and renamed to _tsp_greedy_solve. "
-        "Import from lmd.segmentation is deprecated and will be removed in v3.0.0. "
+        "Import from lmd.segmentation is deprecated and will be removed in v2.0.0. "
         "Please use: from lmd.path import _tsp_greedy_solve",
         DeprecationWarning,
         stacklevel=2,

--- a/tests/unit/test_lmd/test_segmentation.py
+++ b/tests/unit/test_lmd/test_segmentation.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import pytest
 
@@ -260,85 +258,47 @@ class TestDeprecationWarnings:
         """Test that calc_len raises DeprecationWarning when imported from segmentation."""
         from lmd.segmentation import calc_len
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with pytest.warns(DeprecationWarning, match="calc_len has been moved to lmd.path"):
             calc_len(np.array([[0, 0], [1, 1]]))
-
-            assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
-            assert "calc_len has been moved to lmd.path" in str(w[0].message)
 
     def test_tsp_hilbert_solve_deprecation_warning(self) -> None:
         """Test that tsp_hilbert_solve raises DeprecationWarning when imported from segmentation."""
         from lmd.segmentation import tsp_hilbert_solve
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with pytest.warns(DeprecationWarning, match="tsp_hilbert_solve has been moved to lmd.path"):
             tsp_hilbert_solve(np.array([[0.0, 0.0], [1.0, 1.0]]), p=3)
-
-            assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
-            assert "tsp_hilbert_solve has been moved to lmd.path" in str(w[0].message)
 
     def test_tsp_greedy_solve_deprecation_warning(self) -> None:
         """Test that tsp_greedy_solve raises DeprecationWarning when imported from segmentation."""
         from lmd.segmentation import tsp_greedy_solve
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            # Note: tsp_greedy_solve requires umap, so we just check the warning is raised
-            # before the actual call would happen
+        with pytest.warns(DeprecationWarning, match="tsp_greedy_solve has been moved to lmd.path"):
             tsp_greedy_solve(np.array([[0.0, 0.0], [1.0, 1.0]]))
-
-            assert len(w) >= 1
-            assert issubclass(w[0].category, DeprecationWarning)
-            assert "tsp_greedy_solve has been moved to lmd.path" in str(w[0].message)
 
     def test_assign_vertices_deprecation_warning(self) -> None:
         """Test that assign_vertices raises DeprecationWarning when imported from segmentation."""
         from lmd.segmentation import assign_vertices
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with pytest.warns(DeprecationWarning, match="assign_vertices has been moved to lmd.path"):
             assign_vertices(np.array([[0, 0]]), np.array([[0, 0]]))
-
-            assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
-            assert "assign_vertices has been moved to lmd.path" in str(w[0].message)
 
     def test__get_closest_deprecation_warning(self) -> None:
         """Test that _get_closest raises DeprecationWarning when imported from segmentation."""
         from lmd.segmentation import _get_closest
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with pytest.warns(DeprecationWarning, match="_get_closest has been moved to lmd.path"):
             _get_closest([], [0, 1, 2], 10)
-
-            assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
-            assert "_get_closest has been moved to lmd.path" in str(w[0].message)
 
     def test__get_nodes_deprecation_warning(self) -> None:
         """Test that _get_nodes raises DeprecationWarning when imported from segmentation."""
         from lmd.segmentation import _get_nodes
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with pytest.warns(DeprecationWarning, match="_get_nodes has been moved to lmd.path"):
             _get_nodes(np.array([[0, 0]]), np.array([[0, 0]]))
-
-            assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
-            assert "_get_nodes has been moved to lmd.path" in str(w[0].message)
 
     def test__tps_greedy_solve_deprecation_warning(self) -> None:
         """Test that _tps_greedy_solve raises DeprecationWarning when imported from segmentation."""
         from lmd.segmentation import _tps_greedy_solve
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-
+        with pytest.warns(DeprecationWarning, match="_tps_greedy_solve has been moved to lmd.path"):
             _tps_greedy_solve(np.array([[0.0, 0.0], [1.0, 1.0]]))
-
-            assert len(w) >= 1
-            assert issubclass(w[0].category, DeprecationWarning)
-            assert "_tps_greedy_solve has been moved to lmd.path" in str(w[0].message)


### PR DESCRIPTION
Adjust warnings according to update version plan: release v1.6 soon instead of 2.0, but remove deprecated functions in next major release (2.0 instead of 3.0). 