### PR TITLE
Fix type hints and docstrings in core modules

### DIFF
--- a/src/lmd/_utils.py
+++ b/src/lmd/_utils.py
@@ -61,7 +61,7 @@ def _download(
     if output_path is None:
         output_path = tempfile.gettempdir()
 
-    def _sanitize_file_name(file_name):
+    def _sanitize_file_name(file_name: str) -> str:
         if os.name == "nt":
             file_name = file_name.replace("?", "_").replace("*", "_")
         return file_name

--- a/src/lmd/lib/_geom.py
+++ b/src/lmd/lib/_geom.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 import warnings
-from typing import Any
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import geopandas as gpd
 import matplotlib.pyplot as plt
@@ -13,6 +13,11 @@ import pandas as pd
 import shapely
 from lxml import etree as ET
 from svgelements import SVG
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from matplotlib.figure import Figure
 
 
 class Shape:
@@ -23,9 +28,9 @@ class Shape:
         points: np.ndarray = np.empty((1, 2)),
         well: str | None = None,
         name: str | None = None,
-        orientation_transform=None,
+        orientation_transform: np.ndarray | None = None,
         **custom_attributes: dict[str, str],
-    ):
+    ) -> None:
         """Class for creating a single shape.
 
         Args:
@@ -64,7 +69,7 @@ class Shape:
         self.custom_attributes = custom_attributes
 
     @classmethod
-    def from_xml(cls, root, orientation_transform: np.ndarray | None = None):
+    def from_xml(cls, root: ET.Element, orientation_transform: np.ndarray | None = None) -> Shape:
         """Load a shape from an XML shape node. Used internally for reading LMD generated XML files.
 
         Args:
@@ -120,16 +125,13 @@ class Shape:
         scale: float,
         *,
         write_custom_attributes: bool = True,
-    ):
+    ) -> ET.Element:
         """Generate XML shape node needed internally for export.
 
         Args:
             id: Sequential identifier of the shape as used in the LMD XML format.
-
-            orientation_transform (np.array): Pass orientation_transform which is used if no local orientation transform is set.
-
-            scale (float): Scalling factor used to enable higher decimal precision.
-
+            orientation_transform: Pass orientation_transform which is used if no local orientation transform is set.
+            scale: Scalling factor used to enable higher decimal precision.
             write_custom_attributes: Write custom attributes to xml file
 
         Note:
@@ -191,7 +193,8 @@ class Shape:
             warnings.warn(f"Attribute {name} not found in shape attributes. Returning None.", stacklevel=2)
             return None
 
-    def to_shapely(self):
+    def to_shapely(self) -> shapely.Polygon:
+        """Represent shape as :class:`shapely.Polygon`"""
         return shapely.Polygon(self.points)
 
 
@@ -213,7 +216,7 @@ class Collection:
         calibration_points: np.ndarray | None = None,
         orientation_transform: np.ndarray | None = None,
         scale: float = 100,
-    ):
+    ) -> None:
         self.shapes: list[Shape] = []
 
         self.calibration_points: np.ndarray | None = calibration_points
@@ -227,7 +230,7 @@ class Collection:
 
         self.global_coordinates = 1
 
-    def stats(self):
+    def stats(self) -> None:
         """Print statistics about the Collection in the form of:
 
         .. code-block::
@@ -277,7 +280,7 @@ class Collection:
         save_name: str | None = None,
         return_fig: bool = False,
         **kwargs,
-    ):
+    ) -> Union[None, Figure]:  # noqa: UP007 (not supported in python 3.9)
         """This function can be used to plot all shapes of the corresponding shape collection.
 
         Args:
@@ -350,8 +353,9 @@ class Collection:
             return fig
 
         plt.show()
+        return None
 
-    def add_shape(self, shape: Shape):
+    def add_shape(self, shape: Shape) -> None:
         """Add a new shape to the collection.
 
         Args:
@@ -369,7 +373,7 @@ class Collection:
         well: str | None = None,
         name: str | None = None,
         **custom_attributes,
-    ):
+    ) -> None:
         """Directly create a new Shape in the current collection.
 
         Args:
@@ -392,7 +396,7 @@ class Collection:
         )
         self.add_shape(to_add)
 
-    def join(self, collection: Collection, update_orientation_transform: bool = True):
+    def join(self, collection: Collection, update_orientation_transform: bool = True) -> Collection:
         """Join the collection with the shapes of a different collection. The calibration markers of the current collection are kept. Please keep in mind that coordinate systems and calibration points must be compatible for correct joining of collections.
 
         Args:
@@ -460,8 +464,7 @@ class Collection:
 
         return gpd.GeoDataFrame(data=metadata, geometry=geometry)
 
-    # load xml from file
-    def load(self, file_location: str, *, raise_shape_errors: bool = False):
+    def load(self, file_location: str, *, raise_shape_errors: bool = False) -> None:
         """Can be used to load a shape file from XML. Both, XMLs generated with py-lmd and the Leica software can be used.
         Args:
             file_location: File path pointing to the XML file.
@@ -572,8 +575,8 @@ class Collection:
             for _, row in gdf.iterrows()
         ]
 
-    # save xml to file
-    def save(self, file_location: str, encoding: str = "utf-8"):
+    # TODO: Remove encoding (unused)
+    def save(self, file_location: str, encoding: str = "utf-8") -> None:
         """Can be used to save the shape collection as XML file.
 
         file_location: File path pointing to the XML file.
@@ -616,22 +619,22 @@ class Collection:
 
     def svg_to_lmd(
         self,
-        file_location,
-        offset=None,
-        divisor=3,
-        multiplier=60,
-        rotation_matrix=np.eye(2),
-        orientation_transform=None,
-    ):
+        file_location: str | Path,
+        offset: list[float] | None = None,
+        divisor: int = 3,
+        multiplier: float = 60,
+        rotation_matrix: np.ndarray = np.eye(2),
+        orientation_transform: np.ndarray | None = None,
+    ) -> None:
         """Can be used to save the shape collection as XML file.
 
         Args:
             file_location: File path pointing to the SVG file.
-
+            offset: Location of the glyph based on the top left corner. Defaults to no offset.
+            divisor: Parameter which determines the resolution when creating a polygon from a SVG. A larger divisor will lead to fewer datapoints for the glyph.
+            multiplier: Size multiplier
+            rotation_matrix: Rotation of shape
             orientation_transform: Will superseed the global transform of the Collection.
-
-            rotation_matrix:
-
         """
 
         if offset is None:

--- a/src/lmd/lib/_geom.py
+++ b/src/lmd/lib/_geom.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 import warnings
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import geopandas as gpd
 import matplotlib.pyplot as plt
@@ -204,11 +204,12 @@ class Collection:
     Args:
         calibration_points: Calibration coordinates in the form of :math:`(3, 2)`.
         orientation_transform: defines transformations performed on the provided coordinate system prior to export as XML. Defaults to the identity matrix.
+        scale: Scaling factor of shape coordinates
 
     Attributes:
-        shapes (List[Shape]): Contains all shapes which are part of the collection.
-        calibration_points (Optional[np.ndarray]): Calibration coordinates in the form of :math:`(3, 2)`.
-        orientation_transform (np.ndarray): defines transformations performed on the provided coordinate system prior to export as XML. This orientation_transform is always applied to shapes when there is no individual orientation_transform provided.
+        shapes: Contains all shapes which are part of the collection.
+        calibration_points: Calibration coordinates in the form of :math:`(3, 2)`.
+        orientation_transform: defines transformations performed on the provided coordinate system prior to export as XML. This orientation_transform is always applied to shapes when there is no individual orientation_transform provided.
     """
 
     def __init__(
@@ -285,12 +286,9 @@ class Collection:
 
         Args:
             calibration: Controls wether the calibration points should be plotted as crosshairs. Deactivating the crosshairs will result in the size of the canvas adapting to the shapes. Can be especially usefull for small shapes or debugging.
-
-            fig_size: Defaults to :math:`(10, 10)` Controls the size of the matplotlib figure. See `matplotlib documentation <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.figure.html#matplotlib-pyplot-figure>`_ for more information.
-
+            fig_size: Controls the size of the matplotlib figure. See `matplotlib documentation <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.figure.html#matplotlib-pyplot-figure>`_ for more information.
             apply_orientation_transform: Define wether the orientation transform should be applied before plotting.
-
-            save_name (Optional[str], default: None): Specify a filename  for saving the generated figure. By default `None` is provided which will not save a figure.
+            save_name: Specify a filename  for saving the generated figure. By default `None` is provided which will not save a figure.
         """
 
         modes = ["line", "dots"]

--- a/src/lmd/lib/_geom.py
+++ b/src/lmd/lib/_geom.py
@@ -281,7 +281,7 @@ class Collection:
         save_name: str | None = None,
         return_fig: bool = False,
         **kwargs,
-    ) -> Union[None, Figure]:  # noqa: UP007 (not supported in python 3.9)
+    ) -> None | Figure:
         """This function can be used to plot all shapes of the corresponding shape collection.
 
         Args:

--- a/src/lmd/lib/_segmentation.py
+++ b/src/lmd/lib/_segmentation.py
@@ -8,6 +8,7 @@ import sys
 import warnings
 from functools import partial, reduce
 from pathlib import Path
+from typing import Any, Optional, Union
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -27,19 +28,13 @@ class SegmentationLoader:
     """Select single cells from a segmentation and generate cutting data
 
         Args:
-            config (dict): Dict containing configuration parameters. See Note for further explanation.
-
-            processes (int): Number of processes used for parallel processing of cell sets. Total processes can be calculated as `processes * threads`.
-
-            threads (int): Number of threads used for parallel processing of shapes within a cell set. Total processes can be calculated as `processes * threads`.
-
-            cell_sets (list(dict)): List of dictionaries containing the sets of cells which should be sorted into a single well.
-
-            calibration_points (np.array): Array of size '(3,2)' containing the calibration marker coordinates in the '(row, column)' format.
-
-            coords_lookup (None, dict): precalculated lookup table for coordinates of individual cell ids. If not provided will be calculated.
-
-            classes (np.array): Array of classes found in the provided segmentation mask. If not provided will be calculated based on the assumption that cell_ids are assigned in ascending order.
+            config: Dict containing configuration parameters. See Note for further explanation.
+            processes: Number of processes used for parallel processing of cell sets. Total processes can be calculated as `processes * threads`.
+            threads: Number of threads used for parallel processing of shapes within a cell set. Total processes can be calculated as `processes * threads`.
+            cell_sets: List of dictionaries containing the sets of cells which should be sorted into a single well.
+            calibration_points: Array of size '(3,2)' containing the calibration marker coordinates in the '(row, column)' format.
+            coords_lookup: precalculated lookup table for coordinates of individual cell ids. If not provided will be calculated.
+            classes: Array of classes found in the provided segmentation mask. If not provided will be calculated based on the assumption that cell_ids are assigned in ascending order.
 
         Example:
 
@@ -127,7 +122,7 @@ class SegmentationLoader:
     VALID_PATH_OPTIMIZERS = ["none", "hilbert", "greedy"]
     DEFAULT_SEGMENTATION_DTYPE = np.uint64
 
-    def __init__(self, config=None, verbose=False, processes=1):
+    def __init__(self, config: dict[str, Any] | None = None, verbose: bool = False, processes: int = 1) -> None:
         if config is None:
             config = {}
         self.config = config
@@ -148,12 +143,12 @@ class SegmentationLoader:
         self.register_parameter("orientation_transform", np.eye(2))
         self.register_parameter("threads", 10)
 
-        self.coords_lookup = None
+        self.coords_lookup: dict | None = None
         self.processes = processes
 
         self._configure_path_optimizer()
 
-    def _configure_path_optimizer(self):
+    def _configure_path_optimizer(self) -> None:
         # configure path optimizer
         if "path_optimization" in self.config:
             optimization_method = self.config["path_optimization"]
@@ -170,7 +165,7 @@ class SegmentationLoader:
         self.log(f"Path optimizer used for XML generation: {optimization_method}")
         self.optimization_method = pathoptimizer
 
-    def _get_context(self):
+    def _get_context(self) -> None:
         if platform.system() == "Windows":
             self.context = "spawn"
         elif platform.system() == "Darwin":
@@ -181,11 +176,11 @@ class SegmentationLoader:
     def __call__(
         self,
         input_segmentation: np.ndarray | None,
-        cell_sets,
-        calibration_points,
-        coords_lookup=None,
-        classes=np.array([], dtype=np.uint64),
-    ):
+        cell_sets: list[dict],
+        calibration_points: np.ndarray,
+        coords_lookup: dict | None = None,
+        classes: np.ndarray = np.array([], dtype=np.uint64),
+    ) -> Collection:
         if input_segmentation is None:
             assert coords_lookup is not None, "If no input segmentation is provided, a coords_lookup must be provided."
 
@@ -242,6 +237,21 @@ class SegmentationLoader:
         return reduce(lambda a, b: a.join(b), collections)
 
     def generate_cutting_data(self, i: int, cell_set: dict) -> Collection:
+        """Generate the cutting data for a single cell set.
+
+        Converts the loaded classes of the cell set into shapes, optionally merges
+        intersecting shapes, applies smoothing and compression, optimizes the cutting
+        path and assembles the result into a :class:`~lmd.lib.Collection`.
+
+        Args:
+            i: Index of the cell set within the list of cell sets. Used to label
+                debug output.
+            cell_set: Cell set definition. Must contain the ``classes_loaded`` key
+                and may contain a ``well`` key that is propagated to every generated shape.
+
+        Returns:
+            Collection of the generated shapes for this cell set.
+        """
         if 0 in cell_set["classes_loaded"]:
             cell_set["classes_loaded"] = cell_set["classes_loaded"][cell_set["classes_loaded"] != 0]
             warnings.warn("Class 0 is not a valid class and was removed from the cell set", stacklevel=2)
@@ -422,7 +432,25 @@ class SegmentationLoader:
                 ds.new_shape(shape)
         return ds
 
-    def merge_dilated_shapes(self, input_center, input_length, input_coords, dilation=0, erosion=0):
+    def merge_dilated_shapes(
+        self, input_center: list, input_length: list, input_coords: list, dilation: int = 0, erosion: int = 0
+    ) -> tuple[list, list, list]:
+        """Merge intersecting shapes into single shapes after dilation.
+
+        Each shape is dilated, and shapes that overlap within the configured distance
+        heuristic are combined into a single shape. Non-intersecting shapes are passed
+        through unchanged.
+
+        Args:
+            input_center: Center coordinates of the input shapes.
+            input_length: Number of coordinates (vertices) of each input shape.
+            input_coords: Coordinate arrays of the input shapes.
+            dilation: Radius in pixels of the disk used for binary dilation before merging.
+            erosion: Radius in pixels of the disk used for binary erosion before merging.
+
+        Returns:
+            The centers, lengths and coordinate arrays of the merged shapes.
+        """
         print("Intersecting Shapes will be merged into a single shape.")
 
         # initialize all shapes and create dilated coordinates
@@ -507,7 +535,7 @@ class SegmentationLoader:
         )
         return output_center, output_length, output_coords
 
-    def check_cell_set_sanity(self, cell_set):
+    def check_cell_set_sanity(self, cell_set: dict) -> None:
         """Check if cell_set dictionary contains the right keys"""
 
         if "classes" in cell_set:
@@ -523,7 +551,7 @@ class SegmentationLoader:
                 self.log("No well of type str specified for cell set")
                 raise TypeError("No well of type str specified for cell set")
 
-    def load_classes(self, cell_set):
+    def load_classes(self, cell_set: dict) -> Union[list, np.ndarray, str]:  # noqa: UP007 (not supported for python 3.9)
         """Identify cell class definition and load classes
 
         Identify if cell classes are provided as list of integers or as path pointing to a csv file.
@@ -537,11 +565,8 @@ class SegmentationLoader:
                 return cell_set["classes"]
 
         if isinstance(cell_set["classes"], str):
-            # If the path is relative, it is interpreted relative to the project directory
-            if os.path.isabs(cell_set["classes"]):
-                path = cell_set["classes"]
-            else:
-                path = os.path.join(Path(self.directory).parents[0], cell_set["classes"])
+            # If the path is relative, it is interpreted relative to the current working directory
+            path = os.path.abspath(cell_set["classes"])
 
             if os.path.isfile(path):
                 try:
@@ -564,11 +589,29 @@ class SegmentationLoader:
                 "classes argument for a cell set needs to be a list of integer ids or a path pointing to a csv of integer ids."
             )
 
-    def log(self, msg):
+    def log(self, msg: str) -> None:
+        """Print a message if the loader was created in verbose mode.
+
+        Args:
+            msg (str): Message to print.
+        """
         if self.verbose:
             print(msg)
 
-    def register_parameter(self, key, value):
+    def register_parameter(self, key: str, value: Any) -> None:
+        """Register a default configuration parameter.
+
+        Sets ``key`` to ``value`` in the configuration only if it is not already present,
+        so that existing user-provided settings are preserved.
+
+        Args:
+            key: Name of the configuration parameter.
+            value: Default value to assign if the parameter is not already configured.
+
+        Raises:
+            NotImplementedError: If ``key`` is a list (nested parameters are not supported).
+            TypeError: If ``key`` is neither a string nor a list of strings.
+        """
         if isinstance(key, str):
             config_handle = self.config
 

--- a/src/lmd/lib/_segmentation.py
+++ b/src/lmd/lib/_segmentation.py
@@ -7,8 +7,7 @@ import platform
 import sys
 import warnings
 from functools import partial, reduce
-from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Union
 
 import matplotlib.pyplot as plt
 import networkx as nx

--- a/src/lmd/lib/_segmentation.py
+++ b/src/lmd/lib/_segmentation.py
@@ -550,7 +550,7 @@ class SegmentationLoader:
                 self.log("No well of type str specified for cell set")
                 raise TypeError("No well of type str specified for cell set")
 
-    def load_classes(self, cell_set: dict) -> Union[list, np.ndarray, str]:  # noqa: UP007 (not supported for python 3.9)
+    def load_classes(self, cell_set: dict) -> list | np.ndarray | str:
         """Identify cell class definition and load classes
 
         Identify if cell classes are provided as list of integers or as path pointing to a csv file.

--- a/src/lmd/lib/_utils.py
+++ b/src/lmd/lib/_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ProcessPoolExecutor, as_completed
-from typing import Callable
+from typing import Callable, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -44,9 +44,32 @@ def _execute_indexed_parallel(func: Callable, *, args: list, tqdm_kwargs: dict =
 
 
 # TODO: Remove debug argument [Breaking]
-# TODO: Add type hints
-# TODO: Add docstring to public method
-def transform_to_map(coords, dilation=0, erosion=0, coord_format=True, debug=False):
+def transform_to_map(
+    coords: np.ndarray, dilation: int = 0, erosion: int = 0, coord_format: bool = True, debug: bool = False
+) -> Union[np.ndarray | tuple[np.ndarray, np.ndarray]]:  # noqa: UP007 (not supported in python 3.9)
+    """Rasterize a set of coordinates into a binary mask and clean it up morphologically.
+
+    The coordinates are shifted into a local, tightly cropped frame, marked on a
+    binary map, and then processed by binary dilation, binary erosion and hole
+    filling. The result is returned either as a sparse coordinate list (in the
+    original global frame) or as a dense mask together with its offset.
+
+    Args:
+        coords: Array of ``(row, column)`` coordinates describing the shape.
+        dilation: Radius in pixels of the disk used for binary dilation.
+        erosion: Radius in pixels of the disk used for binary erosion.
+        coord_format: If ``True``, return sparse global coordinates. If ``False``,
+            return the dense binary map and the offset that maps it back to the global frame.
+        debug: If ``True``, display the intermediate map before and after
+            morphological processing using matplotlib.
+
+    Returns:
+        - If ``coord_format`` is ``True``, an array of ``(row, column)`` coordinates of all set pixels in the global frame.
+        - If ``coord_format`` is ``False`` a tuple ``(offset_map, offset)`` of the dense binary map and its top-left offset.
+
+    Raises:
+        ValueError: If ``coords`` is empty.
+    """
     # safety boundary which extends the generated map size
     safety_offset = 3
     dilation_offset = int(dilation)
@@ -98,11 +121,11 @@ def transform_to_map(coords, dilation=0, erosion=0, coord_format=True, debug=Fal
 
 # TODO: Remove debugging logic
 def _create_poly(
-    in_tuple,
+    in_tuple: tuple,
     smoothing_filter_size: int = 12,
     rdp_epsilon: float = 0,
     debug: bool = False,
-):
+) -> np.ndarray:
     """Converts a list of pixels into a polygon.
     Args
         smoothing_filter_size (int, default = 12): The smoothing filter is the circular convolution with a vector of length smoothing_filter_size and all elements 1 / smoothing_filter_size.
@@ -143,7 +166,7 @@ def _create_poly(
     return poly + offset
 
 
-def _sort_edges(edges):
+def _sort_edges(edges: np.ndarray) -> np.ndarray:
     """Sorts the vertices of the polygon.
 
     Greedy sorting is performed, might have difficulties with complex shapes.

--- a/src/lmd/lib/_utils.py
+++ b/src/lmd/lib/_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ProcessPoolExecutor, as_completed
-from typing import Callable, Union
+from typing import Callable
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -46,7 +46,7 @@ def _execute_indexed_parallel(func: Callable, *, args: list, tqdm_kwargs: dict =
 # TODO: Remove debug argument [Breaking]
 def transform_to_map(
     coords: np.ndarray, dilation: int = 0, erosion: int = 0, coord_format: bool = True, debug: bool = False
-) -> Union[np.ndarray | tuple[np.ndarray, np.ndarray]]:  # noqa: UP007 (not supported in python 3.9)
+) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
     """Rasterize a set of coordinates into a binary mask and clean it up morphologically.
 
     The coordinates are shifted into a local, tightly cropped frame, marked on a

--- a/src/lmd/path.py
+++ b/src/lmd/path.py
@@ -45,6 +45,21 @@ def calc_len(data: np.ndarray) -> float:
 
 @njit()
 def assign_vertices(hilbert_points: np.ndarray, data_rounded: np.ndarray) -> np.ndarray:
+    """Order data points according to their position along a Hilbert curve.
+
+    For each point on the Hilbert curve, the matching data point is located and its
+    index appended to the output, yielding an ordering of the data points that follows
+    the curve.
+
+    Args:
+        hilbert_points: Array of shape `(M, 2)` with the integer coordinates of the
+            Hilbert curve points, in curve order.
+        data_rounded: Array of shape `(N, 2)` with the data coordinates rounded to the
+            Hilbert curve grid.
+
+    Returns:
+        Array of shape `(N,)` with the indices of `data_rounded` ordered along the Hilbert curve.
+    """
     data_rounded = data_rounded.astype(np.int64)
     hilbert_points = hilbert_points.astype(np.int64)
 

--- a/src/lmd/segmentation.py
+++ b/src/lmd/segmentation.py
@@ -2,9 +2,8 @@ import gc
 import warnings
 from typing import Any, TypeVar, Union
 
-import numba as nb
 import numpy as np
-from numba import njit, prange, types
+from numba import njit
 from scipy.sparse import coo_array
 
 # =============================================================================

--- a/src/lmd/tools.py
+++ b/src/lmd/tools.py
@@ -1,5 +1,6 @@
 import os
 import warnings
+from pathlib import Path
 
 import numpy as np
 
@@ -7,7 +8,7 @@ from lmd._utils import _download_glyphs
 from lmd.lib import Collection, Shape
 
 
-def _get_rotation_matrix(angle: float):
+def _get_rotation_matrix(angle: float) -> np.ndarray:
     """Returns a rotation matrix for clockwise rotation.
 
     Args:
@@ -19,11 +20,11 @@ def _get_rotation_matrix(angle: float):
     return np.array([[np.cos(angle), -np.sin(angle)], [np.sin(angle), np.cos(angle)]])
 
 
-def glyph_path(glyph):
+def glyph_path(glyph: str) -> Path:
     """Returns the path for a glyph of interest. Raises a NotImplementedError if an unknown glyph is requested.
 
     Args:
-        glyph (str): Single glyph as string.
+        glyph: Single glyph as string.
 
     Returns:
         str: Path for the glyph.

--- a/tests/unit/test_lmd/test_lib/test_lib_utils.py
+++ b/tests/unit/test_lmd/test_lib/test_lib_utils.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import operator
-from typing import Optional
 
 import numpy as np
 import pytest
@@ -8,7 +9,7 @@ from lmd.lib import _create_poly, _execute_indexed_parallel, _sort_edges, transf
 
 
 @pytest.mark.parametrize("tqdm_kwargs", [None, {}])
-def test__execute_indexed_parallel(tqdm_kwargs: Optional[dict]) -> None:
+def test__execute_indexed_parallel(tqdm_kwargs: dict | None) -> None:
     """Test parallelized execution"""
     values = range(10)
     result = _execute_indexed_parallel(

--- a/tests/unit/test_lmd/test_path.py
+++ b/tests/unit/test_lmd/test_path.py
@@ -1,6 +1,6 @@
 """Tests for lmd.path module - path optimization functions."""
 
-from typing import Optional
+from __future__ import annotations
 
 import numpy as np
 import pytest
@@ -71,7 +71,7 @@ def test_tsp_hilbert_solve(data: np.ndarray, p: int) -> None:
         "empty_choices",
     ),
 )
-def test__get_closest(used: list[int], choices: list[int], world_size: int, expected_result: Optional[int]) -> None:
+def test__get_closest(used: list[int], choices: list[int], world_size: int, expected_result: int | None) -> None:
     """Test `_get_closest` for finding first unused element from choices"""
     # Act
     result = _get_closest(used=used, choices=choices, world_size=world_size)


### PR DESCRIPTION
Add type hints and docstrings for core modules

Enable modern python type hint syntax by importing `from __future__ import annotations`